### PR TITLE
Use AI to handle theme requests

### DIFF
--- a/src/components/OnboardingPopup.tsx
+++ b/src/components/OnboardingPopup.tsx
@@ -35,63 +35,63 @@ export const OnboardingPopup = ({ isOpen, onClose }: OnboardingPopupProps) => {
       )
     },
     {
-      title: "Smart Features at Your Service",
+      title: t.smartFeaturesService,
       content: (
         <div className="grid grid-cols-2 gap-4">
           <div className="floating-card p-4 text-center">
             <MessageSquare className="h-8 w-8 text-dental-primary mx-auto mb-2" />
-            <h4 className="font-semibold text-sm">AI Chat</h4>
-            <p className="text-xs text-dental-muted-foreground">Get instant answers to dental questions</p>
+            <h4 className="font-semibold text-sm">{t.aiChat}</h4>
+            <p className="text-xs text-dental-muted-foreground">{t.aiChatDesc}</p>
           </div>
           <div className="floating-card p-4 text-center">
             <Calendar className="h-8 w-8 text-dental-secondary mx-auto mb-2" />
-            <h4 className="font-semibold text-sm">Smart Booking</h4>
-            <p className="text-xs text-dental-muted-foreground">Book appointments intelligently</p>
+            <h4 className="font-semibold text-sm">{t.smartBooking}</h4>
+            <p className="text-xs text-dental-muted-foreground">{t.smartBookingDesc}</p>
           </div>
           <div className="floating-card p-4 text-center">
             <Camera className="h-8 w-8 text-dental-accent mx-auto mb-2" />
-            <h4 className="font-semibold text-sm">Photo Analysis</h4>
-            <p className="text-xs text-dental-muted-foreground">Upload photos for AI analysis</p>
+            <h4 className="font-semibold text-sm">{t.photoAnalysis}</h4>
+            <p className="text-xs text-dental-muted-foreground">{t.photoAnalysisDesc}</p>
           </div>
           <div className="floating-card p-4 text-center">
             <Users className="h-8 w-8 text-dental-primary mx-auto mb-2" />
-            <h4 className="font-semibold text-sm">Family Care</h4>
-            <p className="text-xs text-dental-muted-foreground">Book for family members too</p>
+            <h4 className="font-semibold text-sm">{t.familyCare}</h4>
+            <p className="text-xs text-dental-muted-foreground">{t.familyCareDesc}</p>
           </div>
         </div>
       )
     },
     {
-      title: "Book for Anyone in Your Family",
+      title: t.bookForFamilyTitle,
       content: (
         <div className="space-y-4">
           <div className="text-center">
             <Users className="h-16 w-16 text-dental-primary mx-auto mb-3" />
-            <h3 className="text-lg font-semibold mb-2">Family-Friendly Booking</h3>
+            <h3 className="text-lg font-semibold mb-2">{t.familyFriendlyBooking}</h3>
           </div>
           <div className="space-y-3">
             <div className="flex items-center gap-3 p-3 floating-card">
               <CheckCircle className="h-5 w-5 text-dental-secondary" />
-              <span className="text-sm">Book appointments for yourself</span>
+              <span className="text-sm">{t.bookForYourself}</span>
             </div>
             <div className="flex items-center gap-3 p-3 floating-card">
               <CheckCircle className="h-5 w-5 text-dental-secondary" />
-              <span className="text-sm">Book for your children</span>
+              <span className="text-sm">{t.bookForChildren}</span>
             </div>
             <div className="flex items-center gap-3 p-3 floating-card">
               <CheckCircle className="h-5 w-5 text-dental-secondary" />
-              <span className="text-sm">Book for family members</span>
+              <span className="text-sm">{t.bookForFamily}</span>
             </div>
           </div>
           <Badge variant="outline" className="w-full justify-center py-2 border-dental-primary/30 text-dental-primary">
             <Clock className="h-4 w-4 mr-2" />
-            I'll always tell you appointment duration and end time
+            {t.alwaysTellDuration}
           </Badge>
         </div>
       )
     },
     {
-      title: "Ready to Get Started?",
+      title: t.readyToStart,
       content: (
         <div className="text-center space-y-4">
           <div className="relative mx-auto">
@@ -99,13 +99,13 @@ export const OnboardingPopup = ({ isOpen, onClose }: OnboardingPopupProps) => {
               <MessageSquare className="h-16 w-16 text-white mx-auto" />
             </div>
           </div>
-          <h3 className="text-xl font-semibold gradient-text">You're All Set! 🎉</h3>
+          <h3 className="text-xl font-semibold gradient-text">{t.youreAllSet}</h3>
           <p className="text-dental-muted-foreground">
-            Start chatting with me below to book appointments, ask questions, or get dental advice.
+            {t.onboardingEnd}
           </p>
           <div className="bg-dental-primary/10 p-4 rounded-xl">
             <p className="text-sm font-medium text-dental-primary">
-              💡 Pro Tip: Just tell me what's bothering you, and I'll guide you through everything!
+              {t.proTip} {t.proTipText}
             </p>
           </div>
         </div>
@@ -163,14 +163,14 @@ export const OnboardingPopup = ({ isOpen, onClose }: OnboardingPopupProps) => {
                 onClick={prevStep}
                 className="border-dental-primary/30 text-dental-primary hover:bg-dental-primary/10"
               >
-                Back
+                {t.back}
               </Button>
             )}
             <Button 
               onClick={nextStep}
               className="bg-gradient-primary text-white hover:shadow-glow"
             >
-              {currentStep === steps.length - 1 ? "Let's Start!" : "Next"}
+              {currentStep === steps.length - 1 ? t.letsStart : t.next}
             </Button>
           </div>
         </div>

--- a/src/components/chat/InteractiveChatWidgets.tsx
+++ b/src/components/chat/InteractiveChatWidgets.tsx
@@ -568,42 +568,6 @@ const ImageUploadWidget = ({
   );
 };
 
-// Quick Actions Widget
-const QuickActionsWidget = ({ 
-  onAction 
-}: { 
-  onAction: (action: string) => void;
-}) => {
-  const actions = [
-    { id: 'appointments', label: 'Show my appointments', icon: CalendarIcon },
-    { id: 'earliest', label: 'Find earliest slot', icon: Clock },
-    { id: 'emergency', label: 'Emergency booking', icon: AlertTriangle },
-    { id: 'help', label: 'Help & FAQ', icon: HelpCircle }
-  ];
-
-  return (
-    <Card className="max-w-md mx-auto my-4 border-primary/20 shadow-lg">
-      <CardHeader className="text-center">
-        <Info className="h-8 w-8 mx-auto text-primary mb-2" />
-        <CardTitle className="text-lg">Quick Actions</CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-2">
-        {actions.map((action) => (
-          <Button
-            key={action.id}
-            variant="outline"
-            onClick={() => onAction(action.id)}
-            className="w-full justify-start"
-          >
-            <action.icon className="h-4 w-4 mr-2" />
-            {action.label}
-          </Button>
-        ))}
-      </CardContent>
-    </Card>
-  );
-};
-
 // Urgency Slider Widget
 const UrgencySliderWidget = ({ 
   value, 
@@ -656,6 +620,5 @@ export {
   PersonalInfoFormWidget,
   QuickSettingsWidget,
   ImageUploadWidget,
-  QuickActionsWidget,
   UrgencySliderWidget
 };

--- a/src/components/chat/InteractiveDentalChat.tsx
+++ b/src/components/chat/InteractiveDentalChat.tsx
@@ -22,7 +22,6 @@ import {
   PersonalInfoFormWidget,
   QuickSettingsWidget,
   ImageUploadWidget,
-  QuickActionsWidget,
   UrgencySliderWidget
 } from "./InteractiveChatWidgets";
 
@@ -112,19 +111,15 @@ export const InteractiveDentalChat = ({
       const welcomeMessage: ChatMessage = {
         id: crypto.randomUUID(),
         session_id: sessionId,
-        message: user && userProfile ? 
-          `Hello ${userProfile.first_name}! 👋 I'm your dental assistant. How can I help you today?` : 
-          `Hello! 👋 Welcome to First Smile AI. I'm your dental assistant. How can I help you today?`,
+        message: user && userProfile
+          ? t.detailedWelcomeMessageWithName(userProfile.first_name)
+          : t.detailedWelcomeMessage,
         is_bot: true,
         message_type: "text",
         created_at: new Date().toISOString(),
       };
       setMessages([welcomeMessage]);
       
-      // Show quick actions after welcome
-      setTimeout(() => {
-        setActiveWidget('quick-actions');
-      }, 1500);
     }
   };
 
@@ -233,7 +228,6 @@ export const InteractiveDentalChat = ({
 
       if (!appointments || appointments.length === 0) {
         addBotMessage("You don't have any appointments scheduled yet. Would you like to book one? 📅");
-        setTimeout(() => setActiveWidget('quick-actions'), 1000);
         return;
       }
 
@@ -275,9 +269,7 @@ export const InteractiveDentalChat = ({
 
       addBotMessage(responseMessage);
       
-      if (upcoming.length === 0) {
-        setTimeout(() => setActiveWidget('quick-actions'), 2000);
-      }
+      // When there are no upcoming appointments, simply let the conversation continue
 
     } catch (error) {
       console.error("Error fetching appointments:", error);
@@ -332,7 +324,6 @@ Just type what you need or use the quick action buttons! 😊
     `;
     
     addBotMessage(helpMessage);
-    setTimeout(() => setActiveWidget('quick-actions'), 3000);
   };
 
   const loadDentistsForBooking = async () => {
@@ -541,7 +532,7 @@ You'll receive a confirmation email shortly. If you need to reschedule or cancel
         step: 'reason'
       });
 
-      setTimeout(() => setActiveWidget('quick-actions'), 3000);
+
 
     } catch (error) {
       console.error("Error booking appointment:", error);
@@ -569,48 +560,41 @@ You'll receive a confirmation email shortly. If you need to reschedule or cancel
 
     await saveMessage(userMessage);
 
-    // Handle various chat commands
-    setTimeout(() => {
-      if (currentInput.includes('appointment') || currentInput.includes('rendez-vous')) {
-        if (currentInput.includes('show') || currentInput.includes('list') || currentInput.includes('my')) {
-          showAppointments();
-        } else {
-          startBookingFlow();
-        }
-      } else if (currentInput.includes('language')) {
-        if (currentInput.includes('english')) {
-          handleLanguageChange('en');
-        } else if (currentInput.includes('french') || currentInput.includes('français')) {
-          handleLanguageChange('fr');
-        } else if (currentInput.includes('dutch') || currentInput.includes('nederlands')) {
-          handleLanguageChange('nl');
-        } else {
-          setActiveWidget('quick-settings');
-          addBotMessage("I can help you change the language. Please select from the options below:");
-        }
-      } else if (currentInput.includes('dark') || currentInput.includes('light') || currentInput.includes('theme')) {
-        if (currentInput.includes('dark')) {
-          setTheme('dark');
-          addBotMessage("Theme changed to dark mode! 🌙");
-        } else if (currentInput.includes('light')) {
-          setTheme('light');
-          addBotMessage("Theme changed to light mode! ☀️");
-        } else {
-          setActiveWidget('quick-settings');
-          addBotMessage("I can help you change the theme. Please select from the options below:");
-        }
-      } else if (currentInput.includes('help') || currentInput.includes('aide')) {
-        showHelp();
-      } else if (currentInput.includes('emergency') || currentInput.includes('urgent') || currentInput.includes('pain')) {
-        startEmergencyBooking();
-      } else {
-        // Default response with quick actions
-        addBotMessage("I'm here to help! Here are some quick actions you can try:");
-        setTimeout(() => setActiveWidget('quick-actions'), 1000);
-      }
-      
+    const themeIntent = await detectThemeIntent(currentInput);
+    if (themeIntent) {
+      setTheme(themeIntent);
+      addBotMessage(`Theme changed to ${themeIntent} mode! ${themeIntent === 'dark' ? '🌙' : '☀️'}`);
       setIsLoading(false);
-    }, 1000);
+      return;
+    }
+
+    // Handle various chat commands (language and appointments)
+    if (currentInput.includes('appointment') || currentInput.includes('rendez-vous')) {
+      if (currentInput.includes('show') || currentInput.includes('list') || currentInput.includes('my')) {
+        showAppointments();
+      } else {
+        startBookingFlow();
+      }
+    } else if (currentInput.includes('language')) {
+      if (currentInput.includes('english')) {
+        handleLanguageChange('en');
+      } else if (currentInput.includes('french') || currentInput.includes('français')) {
+        handleLanguageChange('fr');
+      } else if (currentInput.includes('dutch') || currentInput.includes('nederlands')) {
+        handleLanguageChange('nl');
+      } else {
+        setActiveWidget('quick-settings');
+        addBotMessage("I can help you change the language. Please select from the options below:");
+      }
+    } else if (currentInput.includes('help') || currentInput.includes('aide')) {
+      showHelp();
+    } else if (currentInput.includes('emergency') || currentInput.includes('urgent') || currentInput.includes('pain')) {
+      startEmergencyBooking();
+    } else {
+      addBotMessage("I'm here to help! Please tell me how I can assist you.");
+    }
+
+    setIsLoading(false);
   };
 
   const handleLanguageChange = (lang: string) => {
@@ -629,6 +613,37 @@ You'll receive a confirmation email shortly. If you need to reschedule or cancel
       title: "Success",
       description: `Language changed to ${langNames[lang as keyof typeof langNames]}`
     });
+  };
+
+  const detectThemeIntent = async (message: string): Promise<'dark' | 'light' | null> => {
+    try {
+      const apiKey = import.meta.env.VITE_OPENAI_API_KEY;
+      if (!apiKey) return null;
+
+      const response = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${apiKey}`
+        },
+        body: JSON.stringify({
+          model: 'gpt-4-turbo',
+          messages: [
+            { role: 'system', content: 'Determine if the user wants a dark or light theme. Respond with "dark", "light", or "none".' },
+            { role: 'user', content: message }
+          ],
+          max_tokens: 1,
+          temperature: 0
+        })
+      });
+
+      const data = await response.json();
+      const intent = data.choices?.[0]?.message?.content?.toLowerCase().trim();
+      if (intent === 'dark' || intent === 'light') return intent;
+    } catch (error) {
+      console.error('Theme intent detection failed', error);
+    }
+    return null;
   };
 
   const handleKeyPress = (e: React.KeyboardEvent) => {
@@ -682,7 +697,6 @@ You'll receive a confirmation email shortly. If you need to reschedule or cancel
             onCancel={() => {
               setActiveWidget(null);
               addBotMessage("Appointment cancelled. Would you like to try a different time?");
-              setTimeout(() => setActiveWidget('quick-actions'), 1000);
             }}
           />
         );
@@ -730,9 +744,6 @@ You'll receive a confirmation email shortly. If you need to reschedule or cancel
             }}
           />
         );
-      
-      case 'quick-actions':
-        return <QuickActionsWidget onAction={handleQuickAction} />;
       
       default:
         return null;

--- a/src/components/chat/NewInteractiveDentalChat.tsx
+++ b/src/components/chat/NewInteractiveDentalChat.tsx
@@ -9,7 +9,6 @@ import { Send, Bot, User as UserIcon } from "lucide-react";
 import { ChatMessage } from "@/types/chat";
 import {
   PrivacyConsentWidget,
-  QuickActionsWidget,
 } from "./InteractiveChatWidgets";
 
 interface NewInteractiveDentalChatProps {
@@ -37,7 +36,7 @@ export const NewInteractiveDentalChat = ({ user }: NewInteractiveDentalChatProps
         created_at: new Date().toISOString(),
       };
       setMessages([welcomeMessage]);
-      setTimeout(() => setActiveWidget('quick-actions'), 1000);
+      // initial interaction does not show quick actions anymore
     }
   }, [user, sessionId]);
 
@@ -89,7 +88,7 @@ export const NewInteractiveDentalChat = ({ user }: NewInteractiveDentalChatProps
         break;
     }
     
-    setTimeout(() => setActiveWidget('quick-actions'), 2000);
+    // continue conversation naturally without quick action prompts
   };
 
   const handleSendMessage = () => {
@@ -109,8 +108,7 @@ export const NewInteractiveDentalChat = ({ user }: NewInteractiveDentalChatProps
     setActiveWidget(null);
 
     setTimeout(() => {
-      addBotMessage("I'm here to help! Here are some quick actions:");
-      setTimeout(() => setActiveWidget('quick-actions'), 1000);
+      addBotMessage("I'm here to help! How can I assist you?");
     }, 500);
   };
 
@@ -158,10 +156,7 @@ export const NewInteractiveDentalChat = ({ user }: NewInteractiveDentalChatProps
               </div>
             </div>
           ))}
-          
-          {activeWidget === 'quick-actions' && (
-            <QuickActionsWidget onAction={handleQuickAction} />
-          )}
+
           
           <div ref={messagesEndRef} />
         </div>

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,14 +1,14 @@
 import { useState, useEffect } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { User, Session } from "@supabase/supabase-js";
-import { DentalChatbot } from "@/components/DentalChatbot";
+import { InteractiveDentalChat } from "@/components/chat/InteractiveDentalChat";
 import { AuthForm } from "@/components/AuthForm";
 import { OnboardingPopup } from "@/components/OnboardingPopup";
 import { LanguageSelection } from "@/components/LanguageSelection";
 import { AppointmentsList } from "@/components/AppointmentsList";
 import { Settings } from "@/components/Settings";
 import { useToast } from "@/hooks/use-toast";
-import { Activity, MessageSquare, Calendar, Plus } from "lucide-react";
+import { Activity, MessageSquare, Calendar } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { useLanguage } from "@/hooks/useLanguage";
 
@@ -204,11 +204,10 @@ const Index = () => {
         {/* Content */}
         <div className="animate-fade-in space-y-6">          
           {activeTab === 'chat' ? (
-            <DentalChatbot 
-              user={user} 
-              triggerBooking={triggerBooking} 
+            <InteractiveDentalChat
+              user={user}
+              triggerBooking={triggerBooking}
               onBookingTriggered={() => setTriggerBooking(false)}
-              onScrollToDentists={scrollToDentists}
             />
           ) : user ? (
             <AppointmentsList user={user} />


### PR DESCRIPTION
## Summary
- drop QuickActionsWidget from interactive chat widgets
- remove quick actions from interactive chat flows
- detect dark or light theme requests with OpenAI

## Testing
- `npm run lint` *(fails: @typescript-eslint errors)*

------
https://chatgpt.com/codex/tasks/task_b_688ba4712064832cbff5c395aa7a56bf