### PR TITLE
Enable widgets in main chat view

### DIFF
--- a/src/components/chat/InteractiveChatWidgets.tsx
+++ b/src/components/chat/InteractiveChatWidgets.tsx
@@ -89,7 +89,6 @@ const AppointmentReasonWidget = ({ onSelect }: { onSelect: (reason: string) => v
     <Card className="max-w-md mx-auto my-4 border-primary/20 shadow-lg">
       <CardHeader className="text-center">
         <CalendarIcon className="h-8 w-8 mx-auto text-primary mb-2" />
-        <CardTitle className="text-lg">What brings you here today?</CardTitle>
       </CardHeader>
       <CardContent className="space-y-3">
         {reasons.map((reason) => (

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { User, Session } from "@supabase/supabase-js";
-import { DentalChatbot } from "@/components/DentalChatbot";
+import { InteractiveDentalChat } from "@/components/chat/InteractiveDentalChat";
 import { AuthForm } from "@/components/AuthForm";
 import { OnboardingPopup } from "@/components/OnboardingPopup";
 import { LanguageSelection } from "@/components/LanguageSelection";
@@ -204,11 +204,10 @@ const Index = () => {
         {/* Content */}
         <div className="animate-fade-in space-y-6">          
           {activeTab === 'chat' ? (
-            <DentalChatbot 
-              user={user} 
-              triggerBooking={triggerBooking} 
+            <InteractiveDentalChat
+              user={user}
+              triggerBooking={triggerBooking}
               onBookingTriggered={() => setTriggerBooking(false)}
-              onScrollToDentists={scrollToDentists}
             />
           ) : user ? (
             <AppointmentsList user={user} />


### PR DESCRIPTION
## Summary
- replace `DentalChatbot` with the richer `InteractiveDentalChat`
- let the AI service decide when to display widgets
- only show quick actions on errors
- remove the "What brings you here today" heading and auto-select a dentist when booking
- remove appointment reason heading so conversation flows naturally with the AI
- refine booking flow so the assistant waits for the user before starting a booking
- let AI trigger the booking flow without keyword detection
- add missing newline at end of key chat files

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any in many files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688be8434fe4832ca06543641aaf8c4c