### PR TITLE
Enable widgets in main chat view

### DIFF
--- a/src/components/chat/InteractiveChatWidgets.tsx
+++ b/src/components/chat/InteractiveChatWidgets.tsx
@@ -89,7 +89,6 @@ const AppointmentReasonWidget = ({ onSelect }: { onSelect: (reason: string) => v
     <Card className="max-w-md mx-auto my-4 border-primary/20 shadow-lg">
       <CardHeader className="text-center">
         <CalendarIcon className="h-8 w-8 mx-auto text-primary mb-2" />
-        <CardTitle className="text-lg">What brings you here today?</CardTitle>
       </CardHeader>
       <CardContent className="space-y-3">
         {reasons.map((reason) => (

--- a/src/components/chat/InteractiveDentalChat.tsx
+++ b/src/components/chat/InteractiveDentalChat.tsx
@@ -57,6 +57,8 @@ export const InteractiveDentalChat = ({
     step: 'reason' // reason -> dentist -> date -> time -> confirm
   });
 
+  const [autoSelectDentist, setAutoSelectDentist] = useState(false);
+
   const { t } = useLanguage();
   const { toast } = useToast();
   const { setTheme } = useTheme();
@@ -121,10 +123,6 @@ export const InteractiveDentalChat = ({
       };
       setMessages([welcomeMessage]);
       
-      // Show quick actions after welcome
-      setTimeout(() => {
-        setActiveWidget('quick-actions');
-      }, 1500);
     }
   };
 
@@ -154,9 +152,82 @@ export const InteractiveDentalChat = ({
       message_type: type,
       created_at: new Date().toISOString(),
     };
-    
+
     setMessages(prev => [...prev, botMessage]);
     saveMessage(botMessage);
+  };
+
+  const generateBotResponse = async (
+    userMessage: string,
+    history: ChatMessage[]
+  ): Promise<{ message: ChatMessage; fallback: boolean; suggestions: string[] }> => {
+    try {
+      const { data, error } = await supabase.functions.invoke('dental-ai-chat', {
+        body: {
+          message: userMessage,
+          conversation_history: history,
+          user_profile: userProfile || (user ? {
+            name: user.email?.split('@')[0] || 'Patient',
+            email: user.email
+          } : {
+            name: 'Guest',
+            email: null
+          })
+        }
+      });
+
+      if (error) throw error;
+
+      const responseText = data.response || data.fallback_response || "I'm sorry, I couldn't process your request.";
+      const result = {
+        id: crypto.randomUUID(),
+        session_id: sessionId,
+        message: responseText,
+        is_bot: true,
+        message_type: 'text',
+        created_at: new Date().toISOString(),
+      };
+      return {
+        message: result,
+        fallback: Boolean(data.fallback_response && !data.response),
+        suggestions: data.suggestions || []
+      };
+    } catch (error) {
+      console.error('Error generating AI response:', error);
+      return {
+        message: {
+          id: crypto.randomUUID(),
+          session_id: sessionId,
+          message: "I'm sorry, I couldn't process your request.",
+          is_bot: true,
+          message_type: 'text',
+          created_at: new Date().toISOString(),
+        },
+        fallback: true,
+        suggestions: []
+      };
+    }
+  };
+
+  const handleSuggestions = (suggestions?: string[]) => {
+    if (!suggestions || suggestions.length === 0) return;
+
+    if (suggestions.includes('appointments-list')) {
+      showAppointments();
+      return;
+    }
+
+    if (suggestions.includes('booking')) {
+      startBookingFlow();
+      return;
+    }
+
+    if (
+      suggestions.includes('skip-patient-selection') ||
+      suggestions.includes('recommend-dentist')
+    ) {
+      startBookingFlow(true);
+    }
   };
 
   const handleConsent = (accepted: boolean) => {
@@ -179,8 +250,10 @@ export const InteractiveDentalChat = ({
         showAppointments();
         break;
       case 'book_appointment':
-      case 'earliest':
         startBookingFlow();
+        break;
+      case 'earliest':
+        startBookingFlow(true);
         break;
       case 'emergency':
         startEmergencyBooking();
@@ -233,7 +306,6 @@ export const InteractiveDentalChat = ({
 
       if (!appointments || appointments.length === 0) {
         addBotMessage("You don't have any appointments scheduled yet. Would you like to book one? 📅");
-        setTimeout(() => setActiveWidget('quick-actions'), 1000);
         return;
       }
 
@@ -275,23 +347,23 @@ export const InteractiveDentalChat = ({
 
       addBotMessage(responseMessage);
       
-      if (upcoming.length === 0) {
-        setTimeout(() => setActiveWidget('quick-actions'), 2000);
-      }
 
-    } catch (error) {
-      console.error("Error fetching appointments:", error);
-      addBotMessage("I'm sorry, I couldn't retrieve your appointments right now. Please try again later.");
-    }
-  };
 
-  const startBookingFlow = () => {
+  } catch (error) {
+    console.error("Error fetching appointments:", error);
+    addBotMessage("I'm sorry, I couldn't retrieve your appointments right now. Please try again later.");
+    setTimeout(() => setActiveWidget('quick-actions'), 1000);
+  }
+};
+
+  const startBookingFlow = (autoSelect = false) => {
     if (!user) {
       addBotMessage("Please log in to book an appointment. You can find the login button at the top right of the page.");
       return;
     }
 
-    addBotMessage("I'll help you book an appointment! 📅 Let's start by understanding what brings you here today.");
+    setAutoSelectDentist(autoSelect);
+    addBotMessage("I'll help you book an appointment! Tell me about your symptoms or reason for visiting first.");
     setBookingFlow({ ...bookingFlow, step: 'reason' });
     setActiveWidget('appointment-reason');
   };
@@ -304,7 +376,7 @@ export const InteractiveDentalChat = ({
 
     setBookingFlow({ ...bookingFlow, reason: 'emergency', urgency: 3, step: 'dentist' });
     addBotMessage("🚨 **Emergency Booking** - I'll find you the earliest available slot with any dentist.");
-    loadDentistsForBooking();
+    loadDentistsForBooking(true);
   };
 
   const showHelp = () => {
@@ -332,10 +404,9 @@ Just type what you need or use the quick action buttons! 😊
     `;
     
     addBotMessage(helpMessage);
-    setTimeout(() => setActiveWidget('quick-actions'), 3000);
   };
 
-  const loadDentistsForBooking = async () => {
+  const loadDentistsForBooking = async (autoSelect = false) => {
     try {
       const { data, error } = await supabase
         .from("dentists")
@@ -351,13 +422,18 @@ Just type what you need or use the quick action buttons! 😊
 
       if (error) throw error;
       
-      setWidgetData({ dentists: data || [] });
-      setActiveWidget('dentist-selection');
-      addBotMessage("Please choose your preferred dentist:");
+      if (autoSelect && data && data.length > 0) {
+        handleDentistSelection(data[0]);
+      } else {
+        setWidgetData({ dentists: data || [] });
+        setActiveWidget('dentist-selection');
+        addBotMessage("Please choose your preferred dentist:");
+      }
       
     } catch (error) {
       console.error("Error fetching dentists:", error);
       addBotMessage("I couldn't load the dentist list. Please try again.");
+      setTimeout(() => setActiveWidget('quick-actions'), 1000);
     }
   };
 
@@ -375,7 +451,7 @@ Just type what you need or use the quick action buttons! 😊
     addBotMessage(`Great! You selected: **${reasonLabels[reason as keyof typeof reasonLabels]}** 🦷`);
     
     setTimeout(() => {
-      loadDentistsForBooking();
+      loadDentistsForBooking(autoSelectDentist);
     }, 1000);
   };
 
@@ -430,12 +506,13 @@ Just type what you need or use the quick action buttons! 😊
         addBotMessage("Please choose your preferred time:");
       }
       
-    } catch (error) {
-      console.error("Error fetching slots:", error);
-      addBotMessage("I couldn't load the available times. Please try a different date.");
-      setTimeout(() => setActiveWidget('calendar'), 1000);
-    }
-  };
+  } catch (error) {
+    console.error("Error fetching slots:", error);
+    addBotMessage("I couldn't load the available times. Please try a different date.");
+    setTimeout(() => setActiveWidget('calendar'), 1000);
+    setTimeout(() => setActiveWidget('quick-actions'), 1500);
+  }
+};
 
   const handleTimeSelection = (time: string) => {
     setBookingFlow({ ...bookingFlow, selectedTime: time, step: 'confirm' });
@@ -541,13 +618,13 @@ You'll receive a confirmation email shortly. If you need to reschedule or cancel
         step: 'reason'
       });
 
-      setTimeout(() => setActiveWidget('quick-actions'), 3000);
 
-    } catch (error) {
-      console.error("Error booking appointment:", error);
-      addBotMessage("I'm sorry, I couldn't complete your booking. Please try again or contact the clinic directly.");
-    }
-  };
+  } catch (error) {
+    console.error("Error booking appointment:", error);
+    addBotMessage("I'm sorry, I couldn't complete your booking. Please try again or contact the clinic directly.");
+    setTimeout(() => setActiveWidget('quick-actions'), 1000);
+  }
+};
 
   const handleSendMessage = async () => {
     if (!inputMessage.trim() || !hasConsented) return;
@@ -569,48 +646,56 @@ You'll receive a confirmation email shortly. If you need to reschedule or cancel
 
     await saveMessage(userMessage);
 
-    // Handle various chat commands
-    setTimeout(() => {
-      if (currentInput.includes('appointment') || currentInput.includes('rendez-vous')) {
-        if (currentInput.includes('show') || currentInput.includes('list') || currentInput.includes('my')) {
-          showAppointments();
-        } else {
-          startBookingFlow();
-        }
-      } else if (currentInput.includes('language')) {
-        if (currentInput.includes('english')) {
-          handleLanguageChange('en');
-        } else if (currentInput.includes('french') || currentInput.includes('français')) {
-          handleLanguageChange('fr');
-        } else if (currentInput.includes('dutch') || currentInput.includes('nederlands')) {
-          handleLanguageChange('nl');
-        } else {
-          setActiveWidget('quick-settings');
-          addBotMessage("I can help you change the language. Please select from the options below:");
-        }
-      } else if (currentInput.includes('dark') || currentInput.includes('light') || currentInput.includes('theme')) {
-        if (currentInput.includes('dark')) {
-          setTheme('dark');
-          addBotMessage("Theme changed to dark mode! 🌙");
-        } else if (currentInput.includes('light')) {
-          setTheme('light');
-          addBotMessage("Theme changed to light mode! ☀️");
-        } else {
-          setActiveWidget('quick-settings');
-          addBotMessage("I can help you change the theme. Please select from the options below:");
-        }
-      } else if (currentInput.includes('help') || currentInput.includes('aide')) {
-        showHelp();
-      } else if (currentInput.includes('emergency') || currentInput.includes('urgent') || currentInput.includes('pain')) {
-        startEmergencyBooking();
+    if (currentInput.includes('language')) {
+      if (currentInput.includes('english')) {
+        handleLanguageChange('en');
+      } else if (currentInput.includes('french') || currentInput.includes('français')) {
+        handleLanguageChange('fr');
+      } else if (currentInput.includes('dutch') || currentInput.includes('nederlands')) {
+        handleLanguageChange('nl');
       } else {
-        // Default response with quick actions
-        addBotMessage("I'm here to help! Here are some quick actions you can try:");
-        setTimeout(() => setActiveWidget('quick-actions'), 1000);
+        setActiveWidget('quick-settings');
+        addBotMessage('I can help you change the language. Please select from the options below:');
       }
-      
       setIsLoading(false);
-    }, 1000);
+      return;
+    }
+
+    if (currentInput.includes('dark') || currentInput.includes('light') || currentInput.includes('theme')) {
+      if (currentInput.includes('dark')) {
+        setTheme('dark');
+        addBotMessage('Theme changed to dark mode! 🌙');
+      } else if (currentInput.includes('light')) {
+        setTheme('light');
+        addBotMessage('Theme changed to light mode! ☀️');
+      } else {
+        setActiveWidget('quick-settings');
+        addBotMessage('I can help you change the theme. Please select from the options below:');
+      }
+      setIsLoading(false);
+      return;
+    }
+
+    if (currentInput.includes('help')) {
+      showHelp();
+      setIsLoading(false);
+      return;
+    }
+
+
+
+    const history = [...messages, userMessage].slice(-10);
+    const { message: botResponse, fallback, suggestions } = await generateBotResponse(userMessage.message, history);
+    setMessages(prev => [...prev, botResponse]);
+    await saveMessage(botResponse);
+
+    handleSuggestions(suggestions);
+
+    if (fallback) {
+      setTimeout(() => setActiveWidget('quick-actions'), 1000);
+    }
+
+    setIsLoading(false);
   };
 
   const handleLanguageChange = (lang: string) => {
@@ -682,7 +767,6 @@ You'll receive a confirmation email shortly. If you need to reschedule or cancel
             onCancel={() => {
               setActiveWidget(null);
               addBotMessage("Appointment cancelled. Would you like to try a different time?");
-              setTimeout(() => setActiveWidget('quick-actions'), 1000);
             }}
           />
         );

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { User, Session } from "@supabase/supabase-js";
-import { DentalChatbot } from "@/components/DentalChatbot";
+import { InteractiveDentalChat } from "@/components/chat/InteractiveDentalChat";
 import { AuthForm } from "@/components/AuthForm";
 import { OnboardingPopup } from "@/components/OnboardingPopup";
 import { LanguageSelection } from "@/components/LanguageSelection";
@@ -204,11 +204,10 @@ const Index = () => {
         {/* Content */}
         <div className="animate-fade-in space-y-6">          
           {activeTab === 'chat' ? (
-            <DentalChatbot 
-              user={user} 
-              triggerBooking={triggerBooking} 
+            <InteractiveDentalChat
+              user={user}
+              triggerBooking={triggerBooking}
               onBookingTriggered={() => setTriggerBooking(false)}
-              onScrollToDentists={scrollToDentists}
             />
           ) : user ? (
             <AppointmentsList user={user} />


### PR DESCRIPTION
## Summary
- replace `DentalChatbot` with the richer `InteractiveDentalChat`
- let the AI service decide when to display widgets
- only show quick actions on errors
- remove the "What brings you here today" heading and auto-select a dentist when booking
- remove appointment reason heading so conversation flows naturally with the AI
- refine booking flow so the assistant waits for the user before starting a booking
- let AI trigger the booking flow without keyword detection
- add missing newline at end of key chat files
- ask for symptoms before booking

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-explicit-any in many files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688be8434fe4832ca06543641aaf8c4c