### PR TITLE
Enhance dentist recommendation flow

### DIFF
--- a/src/components/chat/InteractiveChatWidgets.tsx
+++ b/src/components/chat/InteractiveChatWidgets.tsx
@@ -189,13 +189,20 @@ const TimeSlotsWidget = ({
 };
 
 // Dentist Selection Widget
-const DentistSelectionWidget = ({ 
-  dentists, 
-  onSelect 
-}: { 
-  dentists: any[]; 
+const DentistSelectionWidget = ({
+  dentists,
+  onSelect,
+  recommendedDentists
+}: {
+  dentists: any[];
   onSelect: (dentist: any) => void;
+  recommendedDentists?: string[];
 }) => {
+  const isRecommended = (dentist: any) => {
+    if (!recommendedDentists) return false;
+    const fullName = `${dentist.profiles?.first_name} ${dentist.profiles?.last_name}`;
+    return recommendedDentists.includes(fullName);
+  };
   return (
     <Card className="max-w-md mx-auto my-4 border-primary/20 shadow-lg">
       <CardHeader className="text-center">
@@ -204,11 +211,14 @@ const DentistSelectionWidget = ({
       </CardHeader>
       <CardContent className="space-y-3">
         {dentists.map((dentist) => (
-          <Card key={dentist.id} className="cursor-pointer hover:border-primary/50 transition-colors">
+          <Card key={dentist.id} className={`cursor-pointer hover:border-primary/50 transition-colors ${isRecommended(dentist) ? 'ring-2 ring-green-500' : ''}`}>
             <CardContent className="p-4">
               <div className="flex items-center space-x-3">
-                <div className="w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center">
+                <div className="relative w-12 h-12 rounded-full bg-primary/10 flex items-center justify-center">
                   <UserIcon className="h-6 w-6 text-primary" />
+                  {isRecommended(dentist) && (
+                    <CheckCircle className="absolute -top-1 -right-1 h-4 w-4 text-green-500" />
+                  )}
                 </div>
                 <div className="flex-1">
                   <h3 className="font-semibold">

--- a/src/components/chat/InteractiveDentalChat.tsx
+++ b/src/components/chat/InteractiveDentalChat.tsx
@@ -57,6 +57,10 @@ export const InteractiveDentalChat = ({
     step: 'dentist' // dentist -> date -> time -> confirm
   });
 
+  // Track how many triage questions have been asked before booking
+  const [preBookingQuestions, setPreBookingQuestions] = useState(0);
+  const [bookingBlocked, setBookingBlocked] = useState(false);
+
   const { t } = useLanguage();
   const { toast } = useToast();
   const { setTheme } = useTheme();
@@ -158,7 +162,7 @@ export const InteractiveDentalChat = ({
   const generateBotResponse = async (
     userMessage: string,
     history: ChatMessage[]
-  ): Promise<{ message: ChatMessage; fallback: boolean; suggestions: string[] }> => {
+  ): Promise<{ message: ChatMessage; fallback: boolean; suggestions: string[]; recommendedDentists: string[] }> => {
     try {
       const { data, error } = await supabase.functions.invoke('dental-ai-chat', {
         body: {
@@ -188,7 +192,8 @@ export const InteractiveDentalChat = ({
       return {
         message: result,
         fallback: Boolean(data.fallback_response && !data.response),
-        suggestions: data.suggestions || []
+        suggestions: data.suggestions || [],
+        recommendedDentists: data.recommended_dentist || []
       };
     } catch (error) {
       console.error('Error generating AI response:', error);
@@ -202,12 +207,16 @@ export const InteractiveDentalChat = ({
           created_at: new Date().toISOString(),
         },
         fallback: true,
-        suggestions: []
+        suggestions: [],
+        recommendedDentists: []
       };
     }
   };
 
-  const handleSuggestions = (suggestions?: string[]) => {
+  const handleSuggestions = (
+    suggestions?: string[],
+    recommendedDentists?: string[]
+  ) => {
     if (!suggestions || suggestions.length === 0) return;
 
     if (suggestions.includes('appointments-list')) {
@@ -217,10 +226,36 @@ export const InteractiveDentalChat = ({
 
     if (
       suggestions.includes('booking') ||
-      suggestions.includes('skip-patient-selection') ||
-      suggestions.includes('recommend-dentist')
+      suggestions.includes('skip-patient-selection')
     ) {
+      if (preBookingQuestions < 2) {
+        addBotMessage(
+          "I just need to ask a couple more quick questions so your dentist can focus on what's important and not the admin details."
+        );
+        setBookingBlocked(true);
+        return;
+      }
       startBookingFlow();
+      setBookingBlocked(false);
+      return;
+    }
+
+    if (suggestions.includes('recommend-dentist')) {
+      if (preBookingQuestions < 2) {
+        addBotMessage(
+          "I just need to ask a couple more quick questions so your dentist can focus on what's important and not the admin details."
+        );
+        setBookingBlocked(true);
+        return;
+      }
+      loadDentistsForBooking(false, recommendedDentists);
+      setBookingBlocked(false);
+      return;
+    }
+
+    // Count questions before booking (cap at 5)
+    if (preBookingQuestions < 5) {
+      setPreBookingQuestions(prev => prev + 1);
     }
   };
 
@@ -245,7 +280,15 @@ export const InteractiveDentalChat = ({
         break;
       case 'book_appointment':
       case 'earliest':
-        startBookingFlow();
+        if (preBookingQuestions < 2) {
+          addBotMessage(
+            "I just need to ask a couple more quick questions so your dentist can focus on what's important and not the admin details."
+          );
+          setBookingBlocked(true);
+        } else {
+          startBookingFlow();
+          setBookingBlocked(false);
+        }
         break;
       case 'emergency':
         startEmergencyBooking();
@@ -354,8 +397,9 @@ export const InteractiveDentalChat = ({
       return;
     }
 
-    addBotMessage("I'll help you book an appointment! Let me pick a dentist for you...");
-    await loadDentistsForBooking(true);
+    addBotMessage("I'll help you book an appointment! Please choose a dentist to continue.");
+    setPreBookingQuestions(0);
+    await loadDentistsForBooking(false);
   };
 
   const startEmergencyBooking = () => {
@@ -396,7 +440,7 @@ Just type what you need or use the quick action buttons! 😊
     addBotMessage(helpMessage);
   };
 
-  const loadDentistsForBooking = async (autoSelect = false) => {
+  const loadDentistsForBooking = async (autoSelect = false, recommendedDentists?: string[]) => {
     try {
       const { data, error } = await supabase
         .from("dentists")
@@ -415,7 +459,7 @@ Just type what you need or use the quick action buttons! 😊
       if (autoSelect && data && data.length > 0) {
         handleDentistSelection(data[0]);
       } else {
-        setWidgetData({ dentists: data || [] });
+        setWidgetData({ dentists: data || [], recommendedDentists });
         setActiveWidget('dentist-selection');
         addBotMessage("Please choose your preferred dentist:");
       }
@@ -607,6 +651,8 @@ You'll receive a confirmation email shortly. If you need to reschedule or cancel
         urgency: 1,
         step: 'dentist'
       });
+      setPreBookingQuestions(0);
+      setBookingBlocked(false);
 
 
   } catch (error) {
@@ -635,6 +681,14 @@ You'll receive a confirmation email shortly. If you need to reschedule or cancel
     setActiveWidget(null);
 
     await saveMessage(userMessage);
+
+    if (bookingBlocked && currentInput.includes('why')) {
+      addBotMessage(
+        "Because gathering a bit more info first lets the dentist focus on what's important and not administrative details."
+      );
+      setIsLoading(false);
+      return;
+    }
 
     if (currentInput.includes('language')) {
       if (currentInput.includes('english')) {
@@ -679,11 +733,11 @@ You'll receive a confirmation email shortly. If you need to reschedule or cancel
     }
 
     const history = [...messages, userMessage].slice(-10);
-    const { message: botResponse, fallback, suggestions } = await generateBotResponse(userMessage.message, history);
+    const { message: botResponse, fallback, suggestions, recommendedDentists } = await generateBotResponse(userMessage.message, history);
     setMessages(prev => [...prev, botResponse]);
     await saveMessage(botResponse);
 
-    handleSuggestions(suggestions);
+    handleSuggestions(suggestions, recommendedDentists);
 
     if (fallback) {
       setTimeout(() => setActiveWidget('quick-actions'), 1000);
@@ -726,9 +780,10 @@ You'll receive a confirmation email shortly. If you need to reschedule or cancel
       
       case 'dentist-selection':
         return (
-          <DentistSelectionWidget 
-            dentists={widgetData.dentists || []} 
-            onSelect={handleDentistSelection} 
+          <DentistSelectionWidget
+            dentists={widgetData.dentists || []}
+            onSelect={handleDentistSelection}
+            recommendedDentists={widgetData.recommendedDentists}
           />
         );
       


### PR DESCRIPTION
## Summary
- highlight recommended dentists in DentistSelectionWidget
- let the chat show dentist recommendations separately from booking flow
- preserve recommended_dentist data from API and forward to widgets
- avoid auto-selecting dentist when starting booking
- enforce asking at least two triage questions before starting booking
- gate dentist recommendations until triage questions have been asked

## Testing
- `npm run lint` *(fails: 54 errors, 20 warnings)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_688bfb28131c832c80fc0d82ab087e17