### PR TITLE
Remove automated symptom confirmation message

### DIFF
--- a/src/components/chat/InteractiveDentalChat.tsx
+++ b/src/components/chat/InteractiveDentalChat.tsx
@@ -641,7 +641,6 @@ You'll receive a confirmation email shortly. If you need to reschedule or cancel
         reason: userMessage.message,
         step: 'dentist'
       });
-      addBotMessage(`Got it! You're experiencing: **${userMessage.message}**.`);
     } else {
       // Avoid repeating the confirmation if the reason was already provided
       setBookingFlow({ ...bookingFlow, step: 'dentist' });


### PR DESCRIPTION
## Summary
- remove confirmation message showing the user's symptom

## Testing
- `npm run lint` *(fails: many unrelated lint errors)*

------
https://chatgpt.com/codex/tasks/task_b_688c5e5b27bc832ca3c5b084518fcea8