### PR TITLE
Defer dentist selection until suggested by AI

### DIFF
--- a/src/components/chat/InteractiveDentalChat.tsx
+++ b/src/components/chat/InteractiveDentalChat.tsx
@@ -430,6 +430,7 @@ Just type what you need or use the quick action buttons! 😊
       if (autoSelect && data && data.length > 0) {
         handleDentistSelection(data[0]);
       } else {
+        setBookingFlow(prev => ({ ...prev, step: 'dentist' }));
         setWidgetData({ dentists: data || [], recommendedDentists });
         setActiveWidget('dentist-selection');
         addBotMessage("Please choose your preferred dentist:");
@@ -638,17 +639,10 @@ You'll receive a confirmation email shortly. If you need to reschedule or cancel
     if (!bookingFlow.reason) {
       setBookingFlow({
         ...bookingFlow,
-        reason: userMessage.message,
-        step: 'dentist'
+        reason: userMessage.message
       });
-    } else {
-      // Avoid repeating the confirmation if the reason was already provided
-      setBookingFlow({ ...bookingFlow, step: 'dentist' });
     }
-
-    await loadDentistsForBooking(false);
-    setIsLoading(false);
-    return;
+    // Wait for AI suggestions before continuing the booking flow
   }
 
     if (currentInput.includes('language')) {


### PR DESCRIPTION
## Summary
- remove automatic dentist selection step after user states reason
- set `bookingFlow.step` when loading dentists so AI can prompt appropriately

## Testing
- `npm run lint` *(fails: no explicit types, prefer-const)*
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_b_688c5f75a350832c95e839cdf03f111f