### PR TITLE
Remove emergency trigger on pain keyword

### DIFF
--- a/src/components/chat/InteractiveDentalChat.tsx
+++ b/src/components/chat/InteractiveDentalChat.tsx
@@ -707,7 +707,7 @@ You'll receive a confirmation email shortly. If you need to reschedule or cancel
       return;
     }
 
-    if (currentInput.includes('emergency') || currentInput.includes('urgent') || currentInput.includes('pain')) {
+    if (currentInput.includes('emergency') || currentInput.includes('urgent')) {
       startEmergencyBooking();
       setIsLoading(false);
       return;


### PR DESCRIPTION
## Summary
- remove `pain` keyword from emergency booking trigger

## Testing
- `npm run lint` *(fails: 56 errors, 20 warnings)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_688c67961318832cb14d831655e69950