### PR TITLE
Enable theme/language via AI suggestions

### DIFF
--- a/src/components/chat/InteractiveDentalChat.tsx
+++ b/src/components/chat/InteractiveDentalChat.tsx
@@ -226,6 +226,45 @@ export const InteractiveDentalChat = ({
       return;
     }
 
+    if (suggestions.includes('theme-dark')) {
+      setTheme('dark');
+      addBotMessage('Theme changed to dark mode! \uD83C\uDF19');
+      return;
+    }
+
+    if (suggestions.includes('theme-light')) {
+      setTheme('light');
+      addBotMessage('Theme changed to light mode! \u2600\uFE0F');
+      return;
+    }
+
+    if (suggestions.includes('language-en')) {
+      handleLanguageChange('en');
+      return;
+    }
+
+    if (suggestions.includes('language-fr')) {
+      handleLanguageChange('fr');
+      return;
+    }
+
+    if (suggestions.includes('language-nl')) {
+      handleLanguageChange('nl');
+      return;
+    }
+
+    if (suggestions.includes('language-options')) {
+      setActiveWidget('quick-settings');
+      addBotMessage('Please choose your preferred language:');
+      return;
+    }
+
+    if (suggestions.includes('theme-options')) {
+      setActiveWidget('quick-settings');
+      addBotMessage('Please select a theme:');
+      return;
+    }
+
     if (
       suggestions.includes('booking') ||
       suggestions.includes('skip-patient-selection')
@@ -671,35 +710,6 @@ You'll receive a confirmation email shortly. If you need to reschedule or cancel
     // Wait for AI suggestions before continuing the booking flow
   }
 
-    if (currentInput.includes('language')) {
-      if (currentInput.includes('english')) {
-        handleLanguageChange('en');
-      } else if (currentInput.includes('french') || currentInput.includes('français')) {
-        handleLanguageChange('fr');
-      } else if (currentInput.includes('dutch') || currentInput.includes('nederlands')) {
-        handleLanguageChange('nl');
-      } else {
-        setActiveWidget('quick-settings');
-        addBotMessage('I can help you change the language. Please select from the options below:');
-      }
-      setIsLoading(false);
-      return;
-    }
-
-    if (currentInput.includes('dark') || currentInput.includes('light') || currentInput.includes('theme')) {
-      if (currentInput.includes('dark')) {
-        setTheme('dark');
-        addBotMessage('Theme changed to dark mode! 🌙');
-      } else if (currentInput.includes('light')) {
-        setTheme('light');
-        addBotMessage('Theme changed to light mode! ☀️');
-      } else {
-        setActiveWidget('quick-settings');
-        addBotMessage('I can help you change the theme. Please select from the options below:');
-      }
-      setIsLoading(false);
-      return;
-    }
 
     if (currentInput.includes('help')) {
       showHelp();

--- a/supabase/functions/dental-ai-chat/index.ts
+++ b/supabase/functions/dental-ai-chat/index.ts
@@ -370,10 +370,32 @@ PROFESSIONAL LANGUAGE EXAMPLES WITH RECOMMENDATIONS:
     } else if (recommendedDentist.length > 0 && suggestions.includes('skip-patient-selection')) {
       // If we have both a recommendation and patient info, go directly to dentist selection
       suggestions.push('skip-patient-selection');
-    } else if (lowerResponse.includes('dentist') || 
+    } else if (lowerResponse.includes('dentist') ||
         lowerResponse.includes('appointment') || lowerResponse.includes('booking') ||
         lowerResponse.includes('rendez-vous')) {
       suggestions.push('booking');
+    }
+
+    // Detect language change requests
+    if (lowerMessage.includes('change') && lowerMessage.includes('language')) {
+      if (lowerMessage.includes('english') || lowerMessage.includes('anglais')) {
+        suggestions.push('language-en');
+      } else if (lowerMessage.includes('french') || lowerMessage.includes('francais') || lowerMessage.includes('français')) {
+        suggestions.push('language-fr');
+      } else if (lowerMessage.includes('dutch') || lowerMessage.includes('nederlands')) {
+        suggestions.push('language-nl');
+      } else {
+        suggestions.push('language-options');
+      }
+    }
+
+    // Detect theme change requests
+    if (lowerMessage.includes('dark mode') || (lowerMessage.includes('dark') && lowerMessage.includes('theme'))) {
+      suggestions.push('theme-dark');
+    } else if (lowerMessage.includes('light mode') || (lowerMessage.includes('light') && lowerMessage.includes('theme'))) {
+      suggestions.push('theme-light');
+    } else if (lowerMessage.includes('theme')) {
+      suggestions.push('theme-options');
     }
     
     // No emergency detection - treat all cases as regular consultations


### PR DESCRIPTION
## Summary
- update backend `dental-ai-chat` function to return suggestions for theme or language changes
- trigger theme and language changes in `InteractiveDentalChat` based on AI suggestions
- remove keyword-based detection for theme and language

## Testing
- `npm run lint` *(fails: 56 errors, 20 warnings)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_688c694afe5c832ca6a522a970ff7643