### PR TITLE
Remove keyword-based commands

### DIFF
--- a/src/components/DentalChatbot.tsx
+++ b/src/components/DentalChatbot.tsx
@@ -433,30 +433,8 @@ Type your request...`;
     }, 1000);
   };
 
-  const handleChatCommands = (message: string): boolean => {
-    const lowerMessage = message.toLowerCase();
-
-    // Appointment management commands
-    if (lowerMessage.includes('show') && (lowerMessage.includes('appointment') || lowerMessage.includes('rendez-vous'))) {
-      appointmentManager?.showAppointments();
-      return true;
-    }
-    
-    if (lowerMessage.includes('next appointment') || lowerMessage.includes('prochain rendez-vous')) {
-      appointmentManager?.showAppointments();
-      return true;
-    }
-
-    if (lowerMessage.includes('book') && lowerMessage.includes('appointment')) {
-      setShowChatBooking(true);
-      return true;
-    }
-
-    // Settings commands
-    if (settingsManager?.processSettingsCommand(message)) {
-      return true;
-    }
-
+  // Keyword-based chat commands have been removed so the assistant can interpret messages freely.
+  const handleChatCommands = (_message: string): boolean => {
     return false;
   };
 

--- a/src/components/chat/ChatSettingsManager.tsx
+++ b/src/components/chat/ChatSettingsManager.tsx
@@ -132,48 +132,10 @@ export const ChatSettingsManager = ({ user, onResponse }: ChatSettingsManagerPro
     }
   };
 
-  const processSettingsCommand = (message: string) => {
-    const lowerMessage = message.toLowerCase();
-    
-    // Language change commands
-    if (lowerMessage.includes('change') && lowerMessage.includes('language')) {
-      if (lowerMessage.includes('english') || lowerMessage.includes('en')) {
-        handleLanguageChange('en');
-      } else if (lowerMessage.includes('french') || lowerMessage.includes('français') || lowerMessage.includes('fr')) {
-        handleLanguageChange('fr');
-      } else if (lowerMessage.includes('dutch') || lowerMessage.includes('nederlands') || lowerMessage.includes('nl')) {
-        handleLanguageChange('nl');
-      } else {
-        onResponse("Which language would you like to use? I support English, French (français), and Dutch (Nederlands).");
-      }
-      return true;
-    }
-
-    // Theme change commands
-    if (lowerMessage.includes('dark') && lowerMessage.includes('mode')) {
-      handleThemeChange('dark');
-      return true;
-    }
-    
-    if (lowerMessage.includes('light') && lowerMessage.includes('mode')) {
-      handleThemeChange('light');
-      return true;
-    }
-
-    if (lowerMessage.includes('switch') && lowerMessage.includes('theme')) {
-      const newTheme = theme === 'dark' ? 'light' : 'dark';
-      handleThemeChange(newTheme);
-      return true;
-    }
-
-    // Personal info update commands
-    if ((lowerMessage.includes('update') || lowerMessage.includes('change')) && 
-        (lowerMessage.includes('personal') || lowerMessage.includes('profile') || 
-         lowerMessage.includes('information') || lowerMessage.includes('details'))) {
-      showPersonalInfoEditor();
-      return true;
-    }
-
+  // Previously this function detected keywords like "change language" or "update personal information" and
+  // triggered the associated action automatically. These preset rules have been removed so the assistant can
+  // decide when to apply settings itself. The helper now simply returns `false`.
+  const processSettingsCommand = (_message: string) => {
     return false;
   };
 

--- a/src/components/chat/InteractiveDentalChat.tsx
+++ b/src/components/chat/InteractiveDentalChat.tsx
@@ -212,65 +212,12 @@ export const InteractiveDentalChat = ({
     }
   };
 
-  const handleSuggestions = (suggestions?: string[], recommendedDentists?: string[]) => {
-    if (!suggestions || suggestions.length === 0) return;
-
-    if (suggestions.includes('appointments-list')) {
-      showAppointments();
-      return;
-    }
-
-
-    if (suggestions.includes('recommend-dentist')) {
-      loadDentistsForBooking(false, recommendedDentists);
-      return;
-    }
-
-    if (suggestions.includes('theme-dark')) {
-      setTheme('dark');
-      addBotMessage('Theme changed to dark mode! \uD83C\uDF19');
-      return;
-    }
-
-    if (suggestions.includes('theme-light')) {
-      setTheme('light');
-      addBotMessage('Theme changed to light mode! \u2600\uFE0F');
-      return;
-    }
-
-    if (suggestions.includes('language-en')) {
-      handleLanguageChange('en');
-      return;
-    }
-
-    if (suggestions.includes('language-fr')) {
-      handleLanguageChange('fr');
-      return;
-    }
-
-    if (suggestions.includes('language-nl')) {
-      handleLanguageChange('nl');
-      return;
-    }
-
-    if (suggestions.includes('language-options')) {
-      setActiveWidget('quick-settings');
-      addBotMessage('Please choose your preferred language:');
-      return;
-    }
-
-    if (suggestions.includes('theme-options')) {
-      setActiveWidget('quick-settings');
-      addBotMessage('Please select a theme:');
-      return;
-    }
-
-    if (
-      suggestions.includes('booking') ||
-      suggestions.includes('skip-patient-selection')
-    ) {
-      startBookingFlow();
-    }
+  // This helper used to parse AI-provided suggestion keywords like "appointments-list"
+  // or "language-en" and immediately trigger the related UI actions. To remove
+  // these hard-coded commands, the logic has been stripped out so the assistant
+  // can decide how to respond. The function now does nothing.
+  const handleSuggestions = (_suggestions?: string[], _recommendedDentists?: string[]) => {
+    return;
   };
 
   const handleConsent = (accepted: boolean) => {
@@ -437,9 +384,7 @@ export const InteractiveDentalChat = ({
 - "Find earliest slot"
 
 ⚙️ **Settings**
-- "Change language to English/French/Dutch"
-- "Switch to dark/light mode"
-- "Update my personal information"
+  - Manage language and personal info
 
 📷 **Upload Images**
 - "Upload a photo"


### PR DESCRIPTION
## Summary
- strip out message word detection in ChatSettingsManager
- remove keyword-based chat commands in DentalChatbot
- simplify help text and ignore suggestion keywords in chat handler

## Testing
- `npm run lint` *(fails: 56 errors, 20 warnings)*

------
https://chatgpt.com/codex/tasks/task_b_688c6b3cbd50832ca3c6940d28387efd