### PR TITLE
Merge symptom summary with confirmation

### DIFF
--- a/src/components/chat/InteractiveChatWidgets.tsx
+++ b/src/components/chat/InteractiveChatWidgets.tsx
@@ -209,16 +209,18 @@ const DentistSelectionWidget = ({
 };
 
 // Appointment Confirmation Widget
-const AppointmentConfirmationWidget = ({ 
-  appointment, 
-  onConfirm, 
+const AppointmentConfirmationWidget = ({
+  appointment,
+  onConfirm,
   onCancel,
-  loading = false
-}: { 
-  appointment: any; 
+  loading = false,
+  summary
+}: {
+  appointment: any;
   onConfirm: () => void;
   onCancel: () => void;
   loading?: boolean;
+  summary?: string;
 }) => {
   return (
     <Card className="max-w-md mx-auto my-4 border-primary/20 shadow-lg">
@@ -245,6 +247,9 @@ const AppointmentConfirmationWidget = ({
             <span>{appointment.reason || "General consultation"}</span>
           </div>
         </div>
+        {summary && (
+          <p className="text-sm whitespace-pre-wrap border-t pt-2">{summary}</p>
+        )}
         <div className="flex gap-2">
           <Button variant="outline" onClick={onCancel} className="flex-1">
             Cancel
@@ -624,31 +629,6 @@ const UrgencySliderWidget = ({
   );
 };
 
-// Symptom Summary Widget
-const SymptomSummaryWidget = ({
-  summary,
-  onClose,
-}: {
-  summary: string;
-  onClose?: () => void;
-}) => {
-  return (
-    <Card className="max-w-md mx-auto my-4 border-primary/20 shadow-lg">
-      <CardHeader className="text-center">
-        <Activity className="h-8 w-8 mx-auto text-primary mb-2" />
-        <CardTitle className="text-lg">Symptom Summary</CardTitle>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        <p className="text-sm whitespace-pre-wrap">{summary}</p>
-        {onClose && (
-          <Button variant="outline" onClick={onClose} className="w-full">
-            Close
-          </Button>
-        )}
-      </CardContent>
-    </Card>
-  );
-};
 
 export {
   PrivacyConsentWidget,
@@ -660,6 +640,5 @@ export {
   QuickSettingsWidget,
   ImageUploadWidget,
   QuickActionsWidget,
-  UrgencySliderWidget,
-  SymptomSummaryWidget
+  UrgencySliderWidget
 };


### PR DESCRIPTION
## Summary
- integrate symptom summary text directly into the `AppointmentConfirmationWidget`
- drop the standalone `SymptomSummaryWidget`
- populate summary when showing the confirmation widget

## Testing
- `npm run lint` *(fails: 56 errors, 20 warnings)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_b_688c6f8d7b8c832c9c0f64b2ba5f8987