### PR TITLE
Add terms step to onboarding

### DIFF
--- a/src/components/OnboardingPopup.tsx
+++ b/src/components/OnboardingPopup.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from "react";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Activity, Calendar, Camera, MessageSquare, Users, Clock, CheckCircle } from "lucide-react";
 import { useLanguage } from "@/hooks/useLanguage";
 
@@ -13,6 +14,7 @@ interface OnboardingPopupProps {
 export const OnboardingPopup = ({ isOpen, onClose }: OnboardingPopupProps) => {
   const { t } = useLanguage();
   const [currentStep, setCurrentStep] = useState(0);
+  const [acceptedTerms, setAcceptedTerms] = useState(false);
 
   const steps = [
     {
@@ -91,7 +93,7 @@ export const OnboardingPopup = ({ isOpen, onClose }: OnboardingPopupProps) => {
       )
     },
     {
-      title: "Ready to Get Started?",
+      title: t.readyToStart,
       content: (
         <div className="text-center space-y-4">
           <div className="relative mx-auto">
@@ -99,13 +101,19 @@ export const OnboardingPopup = ({ isOpen, onClose }: OnboardingPopupProps) => {
               <MessageSquare className="h-16 w-16 text-white mx-auto" />
             </div>
           </div>
-          <h3 className="text-xl font-semibold gradient-text">You're All Set! 🎉</h3>
-          <p className="text-dental-muted-foreground">
-            Start chatting with me below to book appointments, ask questions, or get dental advice.
-          </p>
+          <h3 className="text-xl font-semibold gradient-text">{t.youreAllSet}</h3>
+          <p className="text-dental-muted-foreground">{t.onboardingEnd}</p>
+          <p className="text-xs text-dental-muted-foreground">{t.previewNotice}</p>
+          <p className="text-xs text-dental-muted-foreground">{t.aiDisclaimer}</p>
+          <div className="flex items-center justify-center space-x-2">
+            <Checkbox id="accept" checked={acceptedTerms} onCheckedChange={(c) => setAcceptedTerms(!!c)} />
+            <label htmlFor="accept" className="text-sm text-dental-muted-foreground">
+              {t.acceptTerms}
+            </label>
+          </div>
           <div className="bg-dental-primary/10 p-4 rounded-xl">
             <p className="text-sm font-medium text-dental-primary">
-              💡 Pro Tip: Just tell me what's bothering you, and I'll guide you through everything!
+              {t.proTip} {t.proTipText}
             </p>
           </div>
         </div>
@@ -116,7 +124,7 @@ export const OnboardingPopup = ({ isOpen, onClose }: OnboardingPopupProps) => {
   const nextStep = () => {
     if (currentStep < steps.length - 1) {
       setCurrentStep(currentStep + 1);
-    } else {
+    } else if (acceptedTerms) {
       onClose();
     }
   };
@@ -158,19 +166,20 @@ export const OnboardingPopup = ({ isOpen, onClose }: OnboardingPopupProps) => {
           
           <div className="flex gap-2">
             {currentStep > 0 && (
-              <Button 
-                variant="outline" 
+              <Button
+                variant="outline"
                 onClick={prevStep}
                 className="border-dental-primary/30 text-dental-primary hover:bg-dental-primary/10"
               >
-                Back
+                {t.back}
               </Button>
             )}
-            <Button 
+            <Button
               onClick={nextStep}
-              className="bg-gradient-primary text-white hover:shadow-glow"
+              disabled={currentStep === steps.length - 1 && !acceptedTerms}
+              className="bg-gradient-primary text-white hover:shadow-glow disabled:opacity-50"
             >
-              {currentStep === steps.length - 1 ? "Let's Start!" : "Next"}
+              {currentStep === steps.length - 1 ? t.letsStart : t.next}
             </Button>
           </div>
         </div>

--- a/src/hooks/useLanguage.tsx
+++ b/src/hooks/useLanguage.tsx
@@ -196,6 +196,9 @@ interface Translations {
   letsStart: string;
   next: string;
   back: string;
+  previewNotice: string;
+  aiDisclaimer: string;
+  acceptTerms: string;
   
   // Language selection
   selectPreferredLanguage: string;
@@ -398,7 +401,7 @@ How can I help you today?`,
     // Onboarding
     welcomeToFirstSmile: 'Welcome to First Smile AI! 🦷',
     yourAIDentalAssistant: 'Your AI Dental Assistant',
-    onboardingIntro: 'I\'m here to help you with all your dental needs, 24/7. Let me show you what I can do!',
+    onboardingIntro: 'I\'m here to help you with all your dental needs, 24/7. This preview shows how First Smile AI will work in the real world.',
     smartFeaturesService: 'Smart Features at Your Service',
     aiChat: 'AI Chat',
     aiChatDesc: 'Get instant answers to dental questions',
@@ -420,6 +423,9 @@ How can I help you today?`,
     letsStart: 'Let\'s Start!',
     next: 'Next',
     back: 'Back',
+    previewNotice: 'This is a working preview of First Smile AI ready for real-world use.',
+    aiDisclaimer: 'This assistant uses AI. Double check any medical advice.',
+    acceptTerms: 'I accept the Terms and Conditions',
     
     // Language selection
     selectPreferredLanguage: 'Select Your Preferred Language',
@@ -620,7 +626,7 @@ Comment puis-je vous aider aujourd'hui ?`,
     // Onboarding
     welcomeToFirstSmile: 'Bienvenue sur First Smile AI ! 🦷',
     yourAIDentalAssistant: 'Votre Assistant Dentaire IA',
-    onboardingIntro: 'Je suis là pour vous aider avec tous vos besoins dentaires, 24h/24. Laissez-moi vous montrer ce que je peux faire !',
+    onboardingIntro: 'Je suis là pour vous aider avec tous vos besoins dentaires, 24h/24. Cette préversion montre comment First Smile AI fonctionnera dans le monde réel.',
     smartFeaturesService: 'Fonctionnalités Intelligentes à Votre Service',
     aiChat: 'Chat IA',
     aiChatDesc: 'Obtenez des réponses instantanées aux questions dentaires',
@@ -642,6 +648,9 @@ Comment puis-je vous aider aujourd'hui ?`,
     letsStart: 'Commençons !',
     next: 'Suivant',
     back: 'Retour',
+    previewNotice: 'Ceci est une préversion fonctionnelle de First Smile AI prête pour le monde réel.',
+    aiDisclaimer: "Cet assistant utilise l'IA. Vérifiez toujours les conseils médicaux.",
+    acceptTerms: "J'accepte les Conditions Générales",
     
     // Language selection
     selectPreferredLanguage: 'Sélectionnez Votre Langue Préférée',
@@ -842,7 +851,7 @@ Hoe kan ik u vandaag helpen?`,
     // Onboarding
     welcomeToFirstSmile: 'Welkom bij First Smile AI! 🦷',
     yourAIDentalAssistant: 'Uw AI Tandheelkundige Assistent',
-    onboardingIntro: 'Ik ben er om u te helpen met al uw tandheelkundige behoeften, 24/7. Laat me u tonen wat ik kan doen!',
+    onboardingIntro: 'Ik ben er om u te helpen met al uw tandheelkundige behoeften, 24/7. Deze preview toont hoe First Smile AI in de echte wereld zal werken.',
     smartFeaturesService: 'Slimme Functies Tot Uw Dienst',
     aiChat: 'AI Chat',
     aiChatDesc: 'Krijg directe antwoorden op tandheelkundige vragen',
@@ -864,6 +873,9 @@ Hoe kan ik u vandaag helpen?`,
     letsStart: 'Laten we Beginnen!',
     next: 'Volgende',
     back: 'Terug',
+    previewNotice: 'Dit is een werkende preview van First Smile AI klaar voor gebruik in de echte wereld.',
+    aiDisclaimer: 'Deze assistent gebruikt AI. Controleer altijd medisch advies.',
+    acceptTerms: 'Ik accepteer de Algemene Voorwaarden',
     
     // Language selection
     selectPreferredLanguage: 'Selecteer Uw Voorkeurstaal',

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -94,6 +94,7 @@ const Index = () => {
     if (user) {
       localStorage.setItem(`onboarding_${user.id}`, 'true');
     }
+    toast({ description: t.aiDisclaimer });
   };
 
   const handleBookAppointment = () => {


### PR DESCRIPTION
## Summary
- update onboarding popup with preview & AI disclaimers
- require terms acceptance before continuing
- show AI disclaimer toast when onboarding closes
- add new translation strings for the disclaimers in English, French and Dutch

## Testing
- `npm run lint` *(fails: Unexpected any)*

------
https://chatgpt.com/codex/tasks/task_b_688c87afcd6c832c911a6cccd7a5b659