### PR TITLE
feat: add privacy consent and GDPR tools

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { PWAInstallPrompt } from "./components/PWAInstallPrompt";
 import Index from "./pages/Index";
 import DentistProfiles from "./pages/DentistProfiles";
 import Terms from "./pages/Terms";
+import PrivacyPolicy from "./pages/PrivacyPolicy";
 import NotFound from "./pages/NotFound";
 import EmergencyTriage from "./pages/EmergencyTriage";
 import { PaymentSuccess } from "./pages/PaymentSuccess";
@@ -37,6 +38,7 @@ const App = () => (
                 <Route path="/emergency-triage" element={<EmergencyTriage />} />
                 <Route path="/dentists" element={<DentistProfiles />} />
                 <Route path="/terms" element={<Terms />} />
+                <Route path="/privacy" element={<PrivacyPolicy />} />
                 <Route path="/payment-success" element={<PaymentSuccess />} />
                 <Route path="/payment-cancelled" element={<PaymentCancelled />} />
                 {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}

--- a/src/components/AiDisclaimer.tsx
+++ b/src/components/AiDisclaimer.tsx
@@ -1,0 +1,10 @@
+import { useLanguage } from "@/hooks/useLanguage";
+
+export const AiDisclaimer = () => {
+  const { t } = useLanguage();
+  return (
+    <p className="text-xs text-muted-foreground mt-2">
+      {t.aiAdviceDisclaimer}
+    </p>
+  );
+};

--- a/src/components/AuthForm.tsx
+++ b/src/components/AuthForm.tsx
@@ -5,6 +5,7 @@ import { useLanguage } from "@/hooks/useLanguage";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { Checkbox } from "@/components/ui/checkbox";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
@@ -25,6 +26,8 @@ export const AuthForm = ({ compact = false }: AuthFormProps) => {
     lastName: "",
     phone: "",
   });
+  const [acceptTerms, setAcceptTerms] = useState(false);
+  const [healthConsent, setHealthConsent] = useState(false);
   const { toast } = useToast();
 
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -40,7 +43,7 @@ export const AuthForm = ({ compact = false }: AuthFormProps) => {
 
     try {
       const redirectUrl = `${window.location.origin}/`;
-      
+
       const { data, error } = await supabase.auth.signUp({
         email: formData.email,
         password: formData.password,
@@ -50,6 +53,8 @@ export const AuthForm = ({ compact = false }: AuthFormProps) => {
             first_name: formData.firstName,
             last_name: formData.lastName,
             phone: formData.phone,
+            health_data_consent: true,
+            health_data_consent_at: new Date().toISOString(),
           },
         },
       });
@@ -359,15 +364,40 @@ export const AuthForm = ({ compact = false }: AuthFormProps) => {
                       className="pl-10"
                     />
                   </div>
-                </div>
-                <Button type="submit" className="w-full" disabled={isLoading}>
-                  {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-                  {t.createAccountButton}
-                </Button>
-              </form>
               </div>
-            </TabsContent>
-          </Tabs>
+              <div className="space-y-2">
+                <div className="flex items-start space-x-2">
+                  <Checkbox
+                    id="tos"
+                    checked={acceptTerms}
+                    onCheckedChange={(c) => setAcceptTerms(!!c)}
+                  />
+                  <label htmlFor="tos" className="text-sm">
+                    {t.acceptTerms}
+                  </label>
+                </div>
+                <div className="flex items-start space-x-2">
+                  <Checkbox
+                    id="health"
+                    checked={healthConsent}
+                    onCheckedChange={(c) => setHealthConsent(!!c)}
+                  />
+                  <label htmlFor="health" className="text-sm">
+                    {t.consentHealthData}
+                  </label>
+                </div>
+                <p className="text-xs text-muted-foreground">
+                  {t.childConsentNote}
+                </p>
+              </div>
+              <Button type="submit" className="w-full" disabled={isLoading || !acceptTerms || !healthConsent}>
+                {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+                {t.createAccountButton}
+              </Button>
+            </form>
+            </div>
+          </TabsContent>
+        </Tabs>
         </CardContent>
       </Card>
     </div>

--- a/src/components/DentalChatbot.tsx
+++ b/src/components/DentalChatbot.tsx
@@ -20,6 +20,7 @@ import { ChatBookingFlow } from "@/components/chat/ChatBookingFlow";
 import { ChatSettingsManager } from "@/components/chat/ChatSettingsManager";
 import { generateSymptomSummary } from "@/lib/symptoms";
 import { generateMedicalRecordFromChat, createMedicalRecord } from "@/lib/medicalRecords";
+import { AiDisclaimer } from "@/components/AiDisclaimer";
 
 interface DentalChatbotProps {
   user: User | null;
@@ -650,8 +651,8 @@ Type your request...`;
             </div>
           </CardTitle>
         </CardHeader>
-        
         <CardContent className="flex-1 flex flex-col p-0 bg-gradient-hero">
+          <AiDisclaimer />
           <ScrollArea className="flex-1 p-3 sm:p-6">
             <div className="space-y-4 sm:space-y-6">
               {messages.map((message) => (

--- a/src/components/EmergencyTriageWizard.tsx
+++ b/src/components/EmergencyTriageWizard.tsx
@@ -9,6 +9,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Progress } from "@/components/ui/progress";
 import { AlertTriangle, Activity, Clock, Heart, ArrowRight, ArrowLeft, Stethoscope, Shield, FileText } from "lucide-react";
 import { useLanguageDetection } from "@/hooks/useLanguageDetection";
+import { AiDisclaimer } from "@/components/AiDisclaimer";
 
 interface TriageData {
   painLevel: number;
@@ -214,8 +215,9 @@ export const EmergencyTriageWizard = ({ onComplete, onCancel }: EmergencyTriageW
             <Progress value={progress} className="w-full" />
           </div>
         </CardHeader>
-        
+
         <CardContent className="space-y-6">
+          <AiDisclaimer />
           {/* Step 1: Pain Level */}
           {currentStep === 1 && (
             <div className="space-y-4">

--- a/src/components/OnboardingPopup.tsx
+++ b/src/components/OnboardingPopup.tsx
@@ -29,6 +29,7 @@ export const OnboardingPopup = ({ isOpen, onClose }: OnboardingPopupProps) => {
   const { t } = useLanguage();
   const [currentStep, setCurrentStep] = useState(0);
   const [acceptedTerms, setAcceptedTerms] = useState(false);
+  const [acceptedHealth, setAcceptedHealth] = useState(false);
   const [showTerms, setShowTerms] = useState(false);
 
   const steps = [
@@ -139,24 +140,36 @@ export const OnboardingPopup = ({ isOpen, onClose }: OnboardingPopupProps) => {
           <p className="text-xs text-dental-muted-foreground">
             {t.aiDisclaimer}
           </p>
-          <div className="flex items-center justify-center space-x-2">
-            <Checkbox
-              id="accept"
-              checked={acceptedTerms}
-              onCheckedChange={(c) => setAcceptedTerms(!!c)}
-            />
-            <label
-              htmlFor="accept"
-              className="text-sm text-dental-muted-foreground"
-            >
-              {t.acceptTerms}
-            </label>
-            <button
-              onClick={() => setShowTerms(true)}
-              className="text-sm text-dental-primary underline"
-            >
-              {t.viewTerms}
-            </button>
+          <div className="flex flex-col items-start space-y-2">
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="accept"
+                checked={acceptedTerms}
+                onCheckedChange={(c) => setAcceptedTerms(!!c)}
+              />
+              <label
+                htmlFor="accept"
+                className="text-sm text-dental-muted-foreground"
+              >
+                {t.acceptTerms}
+              </label>
+              <button
+                onClick={() => setShowTerms(true)}
+                className="text-sm text-dental-primary underline"
+              >
+                {t.viewTerms}
+              </button>
+            </div>
+            <div className="flex items-center space-x-2">
+              <Checkbox
+                id="healthconsent"
+                checked={acceptedHealth}
+                onCheckedChange={(c) => setAcceptedHealth(!!c)}
+              />
+              <label htmlFor="healthconsent" className="text-sm text-dental-muted-foreground">
+                {t.consentHealthData}
+              </label>
+            </div>
           </div>
           <div className="bg-dental-primary/10 p-4 rounded-xl">
             <p className="text-sm font-medium text-dental-primary">
@@ -221,7 +234,7 @@ export const OnboardingPopup = ({ isOpen, onClose }: OnboardingPopupProps) => {
             )}
             <Button
               onClick={nextStep}
-              disabled={currentStep === steps.length - 1 && !acceptedTerms}
+              disabled={currentStep === steps.length - 1 && (!acceptedTerms || !acceptedHealth)}
               className="bg-gradient-primary text-white hover:shadow-glow disabled:opacity-50"
             >
               {currentStep === steps.length - 1 ? t.letsStart : t.next}

--- a/src/components/PhotoUpload.tsx
+++ b/src/components/PhotoUpload.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Upload, Camera, Image, X } from "lucide-react";
+import { AiDisclaimer } from "@/components/AiDisclaimer";
 
 interface PhotoUploadProps {
   onComplete: (photoUrl: string) => void;
@@ -114,6 +115,7 @@ export const PhotoUpload = ({ onComplete, onCancel }: PhotoUploadProps) => {
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-6">
+        <AiDisclaimer />
         <div className="text-sm text-muted-foreground">
           <p>Vous pouvez télécharger une photo de la zone dentaire concernée pour aider le dentiste à mieux comprendre votre situation.</p>
           <p className="mt-2">Formats acceptés : JPG, PNG • Taille max : 5MB</p>

--- a/src/components/QuickPhotoUpload.tsx
+++ b/src/components/QuickPhotoUpload.tsx
@@ -4,6 +4,7 @@ import { useToast } from "@/hooks/use-toast";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { ImageIcon, Upload, X } from "lucide-react";
+import { AiDisclaimer } from "@/components/AiDisclaimer";
 
 interface QuickPhotoUploadProps {
   onPhotoUploaded: (url: string) => void;
@@ -96,6 +97,7 @@ export const QuickPhotoUpload = ({ onPhotoUploaded, onCancel }: QuickPhotoUpload
     <Card className="w-full max-w-sm mx-auto">
       <CardContent className="p-4">
         <div className="space-y-4">
+          <AiDisclaimer />
           <div className="text-center">
             <h3 className="font-semibold text-gray-900 mb-1">
               Add a photo

--- a/src/components/Settings.tsx
+++ b/src/components/Settings.tsx
@@ -144,6 +144,30 @@ export const Settings = ({ user }: SettingsProps) => {
     }
   };
 
+  const handleDownloadData = async () => {
+    const { data: profile } = await supabase.from('profiles').select('*').eq('user_id', user.id).single();
+    const { data: appointments } = await supabase.from('appointments').select('*').eq('user_id', user.id);
+    const { data: notes } = await supabase.from('notes').select('*').eq('user_id', user.id);
+    const exportData = { profile, appointments, notes };
+    const blob = new Blob([JSON.stringify(exportData, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = url;
+    link.download = 'dentibot_data.json';
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
+  const handleDeleteAccount = async () => {
+    const confirmed = window.confirm(t.deleteAccountConfirm);
+    if (!confirmed) return;
+    await supabase.from('appointments').delete().eq('user_id', user.id);
+    await supabase.from('notes').delete().eq('user_id', user.id);
+    await supabase.from('profiles').delete().eq('user_id', user.id);
+    await supabase.auth.signOut();
+    toast({ title: t.deleteAccount, description: 'Your account has been deleted.' });
+  };
+
   const tabs = [
     { id: 'general' as TabType, label: 'Languages', icon: Globe },
     { id: 'theme' as TabType, label: 'Theme', icon: Sun },
@@ -335,6 +359,15 @@ export const Settings = ({ user }: SettingsProps) => {
               >
                 {loading ? 'Saving...' : 'Save Personal Information'}
               </Button>
+
+              <div className="space-y-2">
+                <Button onClick={handleDownloadData} variant="outline" className="w-full">
+                  {t.downloadMyData}
+                </Button>
+                <Button onClick={handleDeleteAccount} variant="destructive" className="w-full">
+                  {t.deleteAccount}
+                </Button>
+              </div>
 
               <div className="pt-4 border-t border-border">
                 <Button 

--- a/src/components/homepage/Footer.tsx
+++ b/src/components/homepage/Footer.tsx
@@ -1,0 +1,18 @@
+import { Link } from "react-router-dom";
+import { useLanguage } from "@/hooks/useLanguage";
+
+export const Footer = () => {
+  const { t } = useLanguage();
+  return (
+    <footer className="py-6 text-center text-sm text-muted-foreground">
+      <div className="space-x-4">
+        <Link to="/terms" className="underline">
+          {t.termsTitle}
+        </Link>
+        <Link to="/privacy" className="underline">
+          {t.privacyPolicyLink}
+        </Link>
+      </div>
+    </footer>
+  );
+};

--- a/src/hooks/useLanguage.tsx
+++ b/src/hooks/useLanguage.tsx
@@ -52,6 +52,12 @@ interface Translations {
   informationConfirmed: string;
   changesSaved: string;
   privacyNotice: string;
+  consentHealthData: string;
+  childConsentNote: string;
+  downloadMyData: string;
+  deleteAccount: string;
+  deleteAccountConfirm: string;
+  aiAdviceDisclaimer: string;
 
   // Auth
   signOut: string;
@@ -426,6 +432,12 @@ How can I help you today?`,
     invalidPhoneFormat: "Please enter a valid phone number",
     invalidEmailFormat: "Please enter a valid email address",
     requiredField: "This field is required",
+    consentHealthData: "I consent to DentiBot processing my personal and health data for appointment scheduling and dental service support purposes.",
+    childConsentNote: "If you are entering data for a patient under 16, you confirm you are their parent or legal guardian and consent to processing their data.",
+    downloadMyData: "Download My Data",
+    deleteAccount: "Delete My Account & Data",
+    deleteAccountConfirm: "Deleting your account will permanently remove all your personal and health data from DentiBot's systems. This cannot be undone. Are you sure?",
+    aiAdviceDisclaimer: "⚠️ AI suggestions are for informational purposes only and are not a substitute for professional dental advice.",
 
     // Onboarding
     welcomeToFirstSmile: "Welcome to First Smile AI! 🦷",
@@ -682,6 +694,12 @@ Comment puis-je vous aider aujourd'hui ?`,
     invalidPhoneFormat: "Veuillez entrer un numéro de téléphone valide",
     invalidEmailFormat: "Veuillez entrer une adresse email valide",
     requiredField: "Ce champ est obligatoire",
+    consentHealthData: "Je consens à ce que DentiBot traite mes données personnelles et de santé pour la prise de rendez-vous et le support des services dentaires.",
+    childConsentNote: "Si vous saisissez des données pour un patient de moins de 16 ans, vous confirmez être son parent ou tuteur légal et consentez au traitement de ses données.",
+    downloadMyData: "Télécharger Mes Données",
+    deleteAccount: "Supprimer Mon Compte et Mes Données",
+    deleteAccountConfirm: "La suppression de votre compte effacera définitivement toutes vos données personnelles et de santé des systèmes de DentiBot. Cette action est irréversible. Êtes-vous sûr ?",
+    aiAdviceDisclaimer: "⚠️ Les suggestions de l'IA sont fournies à titre informatif uniquement et ne remplacent pas les conseils dentaires professionnels.",
 
     // Onboarding
     welcomeToFirstSmile: "Bienvenue sur First Smile AI ! 🦷",
@@ -940,6 +958,12 @@ Hoe kan ik u vandaag helpen?`,
     invalidPhoneFormat: "Voer een geldig telefoonnummer in",
     invalidEmailFormat: "Voer een geldig e-mailadres in",
     requiredField: "Dit veld is verplicht",
+    consentHealthData: "Ik stem ermee in dat DentiBot mijn persoonlijke- en gezondheidsgegevens verwerkt voor het plannen van afspraken en ondersteuning van tandheelkundige diensten.",
+    childConsentNote: "Als u gegevens invoert voor een patiënt jonger dan 16 jaar, bevestigt u dat u hun ouder of wettelijke voogd bent en toestemt met de verwerking van hun gegevens.",
+    downloadMyData: "Mijn Gegevens Downloaden",
+    deleteAccount: "Mijn Account en Gegevens Verwijderen",
+    deleteAccountConfirm: "Het verwijderen van uw account verwijdert al uw persoonlijke- en gezondheidsgegevens permanent uit de systemen van DentiBot. Dit kan niet ongedaan worden gemaakt. Weet u het zeker?",
+    aiAdviceDisclaimer: "⚠️ AI-suggesties zijn alleen voor informatiedoeleinden en vervangen geen professioneel tandheelkundig advies.",
 
     // Onboarding
     welcomeToFirstSmile: "Welkom bij First Smile AI! 🦷",

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -9,6 +9,7 @@ import { Header } from "@/components/homepage/Header";
 import { HeroSection } from "@/components/homepage/HeroSection";
 import { FeatureCards } from "@/components/homepage/FeatureCards";
 import { StatsSection } from "@/components/homepage/StatsSection";
+import { Footer } from "@/components/homepage/Footer";
 import { AppointmentBookingWithAuth } from "@/components/AppointmentBookingWithAuth";
 import { EmergencyTriageWizard } from "@/components/EmergencyTriageWizard";
 import { FloatingEmergencyButton } from "@/components/FloatingEmergencyButton";
@@ -196,13 +197,13 @@ const Index = () => {
   // Show the new professional homepage for non-authenticated users
   return <div className="min-h-screen mesh-bg">
       <Header user={user} />
-      <HeroSection 
+      <HeroSection
         onBookAppointment={() => setShowAppointmentBooking(true)}
         onStartTriage={() => setShowEmergencyTriage(true)}
       />
       <FeatureCards />
       <StatsSection />
-      
+
       {/* Footer CTA Section */}
       <section className="py-20 border-t border-white/10">
         <div className="container mx-auto px-4 sm:px-6 lg:px-8 text-center">
@@ -223,6 +224,8 @@ const Index = () => {
 
       {/* Floating Emergency Button */}
       <FloatingEmergencyButton onEmergencyClick={() => setShowEmergencyTriage(true)} />
+
+      <Footer />
 
       {/* Language Selection Modal */}
       {showLanguageSelection && <LanguageSelection onLanguageSelected={handleLanguageSelected} />}

--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -1,0 +1,45 @@
+import { AiDisclaimer } from "@/components/AiDisclaimer";
+
+const PrivacyPolicy = () => {
+  return (
+    <div className="max-w-3xl mx-auto p-6 space-y-6">
+      <h1 className="text-3xl font-bold">Privacy Policy</h1>
+      <p>If you are entering data for a patient under 16, you confirm you are their parent or legal guardian and consent to processing their data.</p>
+      <section>
+        <h2 className="text-xl font-semibold">What data we collect</h2>
+        <p>Name, contact info, health history, appointment info.</p>
+      </section>
+      <section>
+        <h2 className="text-xl font-semibold">Why we collect it</h2>
+        <p>Scheduling, reminders, and enabling dentists to treat patients effectively.</p>
+      </section>
+      <section>
+        <h2 className="text-xl font-semibold">Who can access it</h2>
+        <p>The dentist you booked with and their authorized staff.</p>
+      </section>
+      <section>
+        <h2 className="text-xl font-semibold">How we store it</h2>
+        <p>Secure EU-based servers, encrypted, with strict access controls.</p>
+      </section>
+      <section>
+        <h2 className="text-xl font-semibold">Your rights</h2>
+        <p>You can request a copy of your data, correct it, or have it deleted anytime.</p>
+      </section>
+      <section>
+        <h2 className="text-xl font-semibold">Contact</h2>
+        <p>For privacy requests, email privacy@dentibot.be</p>
+      </section>
+      <section>
+        <h2 className="text-xl font-semibold">Legal basis</h2>
+        <p>Explicit consent (checked during registration).</p>
+      </section>
+      <section>
+        <h2 className="text-xl font-semibold">Data retention</h2>
+        <p>We delete inactive patient data after 24 months unless the dentist retains it longer under medical obligations.</p>
+      </section>
+      <AiDisclaimer />
+    </div>
+  );
+};
+
+export default PrivacyPolicy;


### PR DESCRIPTION
## Summary
- add explicit health data consent with guardian note on sign up and onboarding
- provide privacy policy page and footer links
- allow data export and account deletion with AI feature disclaimers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unexpected any and other lint errors)*

------
https://chatgpt.com/codex/tasks/task_b_688f446f8d18832ca19dc56b884f2a71