### PR TITLE
feat: add AI opt-in prompt

### DIFF
--- a/src/components/UnifiedDashboard.tsx
+++ b/src/components/UnifiedDashboard.tsx
@@ -6,6 +6,15 @@ import { PatientDashboard } from "./PatientDashboard";
 import { DentistDashboard } from "../pages/DentistDashboard";
 import { Card, CardContent } from "@/components/ui/card";
 import { Loader2 } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
 
 interface UnifiedDashboardProps {
   user: User;
@@ -14,10 +23,13 @@ interface UnifiedDashboardProps {
 export const UnifiedDashboard = ({ user }: UnifiedDashboardProps) => {
   const [userRole, setUserRole] = useState<'patient' | 'dentist' | null>(null);
   const [loading, setLoading] = useState(true);
+  const [showAiPrompt, setShowAiPrompt] = useState(false);
+  const [profileId, setProfileId] = useState<string | null>(null);
   const { toast } = useToast();
 
   useEffect(() => {
     fetchUserRole();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [user]);
 
   const fetchUserRole = async () => {
@@ -27,7 +39,7 @@ export const UnifiedDashboard = ({ user }: UnifiedDashboardProps) => {
       // First get the user's profile
       const { data: profile, error: profileError } = await supabase
         .from('profiles')
-        .select('id, role')
+        .select('id, role, ai_opt_out, ai_never_prompt')
         .eq('user_id', user.id)
         .maybeSingle();
 
@@ -42,6 +54,15 @@ export const UnifiedDashboard = ({ user }: UnifiedDashboardProps) => {
         console.log('No profile found, defaulting to patient');
         setUserRole('patient');
         return;
+      }
+
+      setProfileId(profile.id);
+      if (profile.ai_opt_out && !profile.ai_never_prompt) {
+        const promptKey = `ai_prompt_${user.id}`;
+        if (!sessionStorage.getItem(promptKey)) {
+          setShowAiPrompt(true);
+          sessionStorage.setItem(promptKey, 'shown');
+        }
       }
 
       console.log('User profile role:', profile.role);
@@ -69,18 +90,55 @@ export const UnifiedDashboard = ({ user }: UnifiedDashboardProps) => {
         console.log('User role is not dentist, setting to patient');
         setUserRole('patient');
       }
-    } catch (error: any) {
+    } catch (error: unknown) {
       console.error('Error fetching user role:', error);
       // Default to patient if there's an error
       setUserRole('patient');
+      const message = error instanceof Error ? error.message : 'Unknown error';
       toast({
         title: "Error",
-        description: `Error loading dashboard: ${error.message}`,
+        description: `Error loading dashboard: ${message}`,
         variant: "destructive",
       });
     } finally {
       setLoading(false);
     }
+  };
+
+  const handleEnableAi = async () => {
+    if (!profileId) return;
+    const { error } = await supabase
+      .from('profiles')
+      .update({ ai_opt_out: false })
+      .eq('id', profileId);
+    if (error) {
+      toast({
+        title: 'Error',
+        description: 'Failed to enable AI',
+        variant: 'destructive',
+      });
+      return;
+    }
+    toast({ title: 'AI Enabled', description: 'Smart assistant activated.' });
+    setShowAiPrompt(false);
+  };
+
+  const handleNeverAsk = async () => {
+    if (!profileId) return;
+    const { error } = await supabase
+      .from('profiles')
+      .update({ ai_never_prompt: true })
+      .eq('id', profileId);
+    if (error) {
+      toast({
+        title: 'Error',
+        description: 'Failed to update preference',
+        variant: 'destructive',
+      });
+      return;
+    }
+    toast({ title: 'Preference Saved', description: 'We will not ask again.' });
+    setShowAiPrompt(false);
   };
 
   if (loading) {
@@ -98,12 +156,33 @@ export const UnifiedDashboard = ({ user }: UnifiedDashboardProps) => {
   }
 
   return (
-    <div className="min-h-screen mesh-bg">
-      {userRole === 'dentist' ? (
-        <DentistDashboard user={user} />
-      ) : (
-        <PatientDashboard user={user} />
-      )}
-    </div>
+    <>
+      <div className="min-h-screen mesh-bg">
+        {userRole === 'dentist' ? (
+          <DentistDashboard user={user} />
+        ) : (
+          <PatientDashboard user={user} />
+        )}
+      </div>
+      <Dialog open={showAiPrompt} onOpenChange={setShowAiPrompt}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Enable Smart AI Assistant?</DialogTitle>
+            <DialogDescription>
+              DentiBot’s AI can help you describe your symptoms faster. Would you like to enable it?
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button onClick={handleEnableAi}>Enable AI</Button>
+            <Button variant="secondary" onClick={() => setShowAiPrompt(false)}>
+              Keep Disabled
+            </Button>
+            <Button variant="ghost" onClick={handleNeverAsk}>
+              Never Ask Again
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 };

--- a/src/lib/dentibot.test.ts
+++ b/src/lib/dentibot.test.ts
@@ -90,6 +90,13 @@ describe('AI opt-in prompt', () => {
     profile = handleAiPromptResponse(profile, 'never');
     expect(shouldShowAiPrompt(profile)).toBe(false);
   });
+
+  it('disables opt-out when enabling', () => {
+    let profile: PatientProfile = { id: 'p2', aiOptOut: true };
+    profile = handleAiPromptResponse(profile, 'enable');
+    expect(profile.aiOptOut).toBe(false);
+    expect(shouldShowAiPrompt(profile)).toBe(false);
+  });
 });
 
 describe('dentist profile editing', () => {


### PR DESCRIPTION
## Summary
- prompt users who previously opted out of AI to re-enable it
- allow never-ask-again preference and update profile settings
- extend AI prompt tests to cover enabling behaviour

## Testing
- `npm run lint --silent` *(fails: many existing lint errors across repo)*
- `npx eslint src/components/UnifiedDashboard.tsx src/lib/dentibot.test.ts`
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_b_688f4eb6be68832cbde25cff4efc0ee0