### PR TITLE
feat: add profile completion dialog and dentist fields

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ import { ThemeProvider } from "next-themes";
 import { LanguageProvider } from "./hooks/useLanguage";
 import { ErrorBoundary } from "@/components/ErrorBoundary";
 import { PWAInstallPrompt } from "./components/PWAInstallPrompt";
+import ProfileCompletionDialog from "./components/ProfileCompletionDialog";
 import Index from "./pages/Index";
 import DentistProfiles from "./pages/DentistProfiles";
 import Terms from "./pages/Terms";
@@ -28,11 +29,12 @@ const App = () => (
         disableTransitionOnChange={false}
       >
         <LanguageProvider>
-          <TooltipProvider>
-            <Toaster />
-            <Sonner />
-            <PWAInstallPrompt />
-            <BrowserRouter>
+            <TooltipProvider>
+              <Toaster />
+              <Sonner />
+              <PWAInstallPrompt />
+              <ProfileCompletionDialog />
+              <BrowserRouter>
               <Routes>
                 <Route path="/" element={<Index />} />
                 <Route path="/emergency-triage" element={<EmergencyTriage />} />

--- a/src/components/AppointmentBooking.tsx
+++ b/src/components/AppointmentBooking.tsx
@@ -24,7 +24,7 @@ interface AppointmentBookingProps {
 interface Dentist {
   id: string;
   profile_id: string;
-  specialization: string;
+  specialty: string;
   profiles: {
     first_name: string;
     last_name: string;
@@ -133,7 +133,7 @@ export const AppointmentBooking = ({ user, selectedDentist: preSelectedDentist, 
         .select(`
           id,
           profile_id,
-          specialization,
+          specialty,
           profiles:profile_id (
             first_name,
             last_name
@@ -289,7 +289,7 @@ export const AppointmentBooking = ({ user, selectedDentist: preSelectedDentist, 
                         <UserIcon className="h-4 w-4 mr-3 text-blue-600" />
                         <div>
                           <div className="font-medium">Dr {dentist.profiles.first_name} {dentist.profiles.last_name}</div>
-                          <div className="text-sm text-gray-500">{dentist.specialization}</div>
+                          <div className="text-sm text-gray-500">{dentist.specialty}</div>
                         </div>
                       </div>
                     </SelectItem>

--- a/src/components/AppointmentsList.tsx
+++ b/src/components/AppointmentsList.tsx
@@ -31,7 +31,7 @@ interface Appointment {
   notes?: string;
   dentist: {
     id: string;
-    specialization?: string;
+    specialty?: string;
     profile: {
       id: string;
       first_name: string;
@@ -104,7 +104,7 @@ export const AppointmentsList = ({ user }: AppointmentsListProps) => {
           notes,
           dentists:dentist_id (
             id,
-            specialization,
+            specialty,
             profiles:profile_id (
               id,
               first_name,
@@ -132,7 +132,7 @@ export const AppointmentsList = ({ user }: AppointmentsListProps) => {
         notes: apt.notes,
         dentist: {
           id: apt.dentists.id,
-          specialization: apt.dentists.specialization,
+          specialty: apt.dentists.specialty,
           profile: {
             id: apt.dentists.profiles.id,
             first_name: apt.dentists.profiles.first_name,
@@ -326,14 +326,14 @@ export const AppointmentsList = ({ user }: AppointmentsListProps) => {
                                     Dr. {appointment.dentist.profile.first_name} {appointment.dentist.profile.last_name}
                                   </span>
                                 </div>
-                                {appointment.dentist.specialization && (
-                                  <div className="flex items-center gap-2 mb-2">
-                                    <MapPin className="h-3 w-3 sm:h-4 sm:w-4 text-dental-muted-foreground flex-shrink-0" />
-                                    <span className="text-xs sm:text-sm text-dental-muted-foreground truncate">
-                                      {appointment.dentist.specialization}
-                                    </span>
-                                  </div>
-                                )}
+                                  {appointment.dentist.specialty && (
+                                    <div className="flex items-center gap-2 mb-2">
+                                      <MapPin className="h-3 w-3 sm:h-4 sm:w-4 text-dental-muted-foreground flex-shrink-0" />
+                                      <span className="text-xs sm:text-sm text-dental-muted-foreground truncate">
+                                        {appointment.dentist.specialty}
+                                      </span>
+                                    </div>
+                                  )}
                                 {appointment.dentist.profile.phone && (
                                   <div className="flex items-center gap-2">
                                     <Phone className="h-3 w-3 sm:h-4 sm:w-4 text-dental-muted-foreground flex-shrink-0" />

--- a/src/components/DentistRecommendations.tsx
+++ b/src/components/DentistRecommendations.tsx
@@ -18,7 +18,7 @@ import {
 interface DentistRecommendation {
   id: string;
   profile_id: string;
-  specialization: string;
+  specialty: string;
   average_rating: number;
   total_ratings: number;
   expertise_score: number;
@@ -71,7 +71,7 @@ export const DentistRecommendations = ({
         .select(`
           id,
           profile_id,
-          specialization,
+          specialty,
           average_rating,
           total_ratings,
           expertise_score,
@@ -139,22 +139,22 @@ export const DentistRecommendations = ({
       reasons.push("Dentiste expérimenté");
     }
 
-    // Enhanced specialization matching with triage data (30% of total score)
-    const specializationScore = getSpecializationScore(
-      dentist.specialization, 
+    // Enhanced specialty matching with triage data (30% of total score)
+    const specialtyScore = getSpecialtyScore(
+      dentist.specialty, 
       symptoms, 
       urgency, 
       triageData
     );
-    score += specializationScore.score;
-    if (specializationScore.reason) {
-      reasons.push(specializationScore.reason);
+    score += specialtyScore.score;
+    if (specialtyScore.reason) {
+      reasons.push(specialtyScore.reason);
     }
 
     // Allergy compatibility (critical factor)
     if (triageData?.allergies?.length) {
       const allergyCompatibilityScore = getAllergyCompatibilityScore(
-        dentist.specialization,
+        dentist.specialty,
         triageData.allergies
       );
       score += allergyCompatibilityScore.score;
@@ -163,10 +163,10 @@ export const DentistRecommendations = ({
       }
     }
 
-    // Problem type specialization bonus
+    // Problem type specialty bonus
     if (triageData?.problemType) {
       const problemScore = getProblemTypeScore(
-        dentist.specialization,
+        dentist.specialty,
         triageData.problemType,
         urgency
       );
@@ -179,7 +179,7 @@ export const DentistRecommendations = ({
     // Emergency indicators penalty for non-specialists
     if (triageData?.urgencyIndicators?.length && urgency >= 4) {
       const emergencyScore = getEmergencySpecialistScore(
-        dentist.specialization,
+        dentist.specialty,
         triageData.urgencyIndicators
       );
       score += emergencyScore.score;
@@ -212,8 +212,8 @@ export const DentistRecommendations = ({
     };
   };
 
-  const getSpecializationScore = (
-    specialization: string,
+  const getSpecialtyScore = (
+    specialty: string,
     symptoms: string[],
     urgency: number,
     triageData?: {
@@ -225,7 +225,7 @@ export const DentistRecommendations = ({
       medicalHistory?: string[];
     }
   ): { score: number; reason?: string } => {
-    const spec = specialization?.toLowerCase() || '';
+    const spec = specialty?.toLowerCase() || '';
     
     // Critical emergency indicators require specialists
     if (triageData?.urgencyIndicators?.some(indicator => 
@@ -290,10 +290,10 @@ export const DentistRecommendations = ({
   };
 
   const getAllergyCompatibilityScore = (
-    specialization: string,
+    specialty: string,
     allergies: string[]
   ): { score: number; reason?: string } => {
-    const spec = specialization?.toLowerCase() || '';
+    const spec = specialty?.toLowerCase() || '';
     
     // Critical allergies that require specialist knowledge
     const criticalAllergies = ['local_anesthetic', 'latex'];
@@ -316,13 +316,13 @@ export const DentistRecommendations = ({
   };
 
   const getProblemTypeScore = (
-    specialization: string,
+    specialty: string,
     problemType: string,
     urgency: number
   ): { score: number; reason?: string } => {
-    const spec = specialization?.toLowerCase() || '';
+    const spec = specialty?.toLowerCase() || '';
     
-    const problemSpecializations = {
+    const problemSpecialties = {
       'abscess': ['endodontie', 'urgence'],
       'broken_tooth': ['chirurgie', 'urgence', 'prothèse'],
       'gum_problem': ['parodontie'],
@@ -331,10 +331,10 @@ export const DentistRecommendations = ({
       'post_surgery': ['chirurgie', 'urgence']
     };
 
-    const requiredSpecs = problemSpecializations[problemType as keyof typeof problemSpecializations] || [];
-    const hasSpecialization = requiredSpecs.some(reqSpec => spec.includes(reqSpec));
+    const requiredSpecs = problemSpecialties[problemType as keyof typeof problemSpecialties] || [];
+    const hasSpecialty = requiredSpecs.some(reqSpec => spec.includes(reqSpec));
 
-    if (hasSpecialization) {
+    if (hasSpecialty) {
       const bonus = urgency >= 4 ? 5 : 3;
       return { score: 15 + bonus, reason: `Spécialisé en ${problemType.replace('_', ' ')}` };
     }
@@ -343,10 +343,10 @@ export const DentistRecommendations = ({
   };
 
   const getEmergencySpecialistScore = (
-    specialization: string,
+    specialty: string,
     urgencyIndicators: string[]
   ): { score: number; reason?: string } => {
-    const spec = specialization?.toLowerCase() || '';
+    const spec = specialty?.toLowerCase() || '';
     
     const criticalIndicators = [
       'difficulty_breathing', 'facial_swelling', 'difficulty_swallowing', 
@@ -440,7 +440,7 @@ export const DentistRecommendations = ({
                           Dr. {dentist.profiles.first_name} {dentist.profiles.last_name}
                         </h4>
                         <p className="text-sm text-muted-foreground">
-                          {dentist.specialization}
+                          {dentist.specialty}
                         </p>
                       </div>
                       <Badge variant={badge.variant}>

--- a/src/components/DentistSelection.tsx
+++ b/src/components/DentistSelection.tsx
@@ -10,7 +10,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 interface Dentist {
   id: string;
   profile_id: string;
-  specialization: string;
+  specialty: string;
   is_active: boolean;
   profiles: {
     first_name: string;
@@ -75,8 +75,8 @@ export const DentistSelection = ({ onSelectDentist, selectedDentistId, recommend
     return `${dentist.profiles.first_name[0]}${dentist.profiles.last_name[0]}`;
   };
 
-  const getSpecializationColor = (specialization: string | null) => {
-    switch (specialization?.toLowerCase()) {
+  const getSpecialtyColor = (specialty: string | null) => {
+    switch (specialty?.toLowerCase()) {
       case 'orthodontics':
         return 'bg-blue-100 text-blue-800';
       case 'oral surgery':
@@ -187,9 +187,9 @@ export const DentistSelection = ({ onSelectDentist, selectedDentistId, recommend
                   
                   <Badge 
                     variant="secondary" 
-                    className={`mt-1 ${getSpecializationColor(dentist.specialization)}`}
+                    className={`mt-1 ${getSpecialtyColor(dentist.specialty)}`}
                   >
-                    {dentist.specialization || 'General Dentist'}
+                    {dentist.specialty || 'General Dentist'}
                   </Badge>
 
                   <div className="flex items-center mt-3 space-x-4 text-sm text-gray-600">

--- a/src/components/EmergencyBookingFlow.tsx
+++ b/src/components/EmergencyBookingFlow.tsx
@@ -42,7 +42,7 @@ interface TriageData {
 interface Dentist {
   id: string;
   profile_id: string;
-  specialization: string;
+  specialty: string;
   profiles: {
     first_name: string;
     last_name: string;
@@ -80,7 +80,7 @@ export const EmergencyBookingFlow = ({ user, onComplete, onCancel }: EmergencyBo
         .select(`
           id,
           profile_id,
-          specialization,
+          specialty,
           profiles (
             first_name,
             last_name
@@ -460,7 +460,7 @@ export const EmergencyBookingFlow = ({ user, onComplete, onCancel }: EmergencyBo
                   <p className="font-medium">
                     ✅ Dentiste sélectionné: Dr. {selectedDentist.profiles.first_name} {selectedDentist.profiles.last_name}
                   </p>
-                  <p className="text-sm text-muted-foreground">{selectedDentist.specialization}</p>
+                  <p className="text-sm text-muted-foreground">{selectedDentist.specialty}</p>
                 </div>
                 <Badge variant="default">Sélectionné</Badge>
               </div>

--- a/src/components/PatientDossier.tsx
+++ b/src/components/PatientDossier.tsx
@@ -24,7 +24,7 @@ interface MedicalRecord {
     profile?: {
       first_name: string;
       last_name: string;
-      specialization?: string;
+      specialty?: string;
     };
   } | null;
 }
@@ -91,7 +91,7 @@ export const PatientDossier = ({ user, onBack }: PatientDossierProps) => {
       if (dentistIds.length > 0) {
         const { data: dentistsData, error: dentistsError } = await supabase
           .from('dentists')
-          .select('id, profile:profiles(first_name, last_name, specialization)')
+          .select('id, profile:profiles(first_name, last_name, specialty)')
           .in('id', dentistIds);
         if (dentistsError) {
           console.error('Error loading dentists info:', dentistsError);
@@ -234,8 +234,8 @@ export const PatientDossier = ({ user, onBack }: PatientDossierProps) => {
                           {record.dentist?.profile && (
                             <p className="text-xs text-muted-foreground text-right">
                               Dr. {record.dentist.profile.first_name} {record.dentist.profile.last_name}
-                              {record.dentist.profile.specialization && (
-                                <span className="block">{record.dentist.profile.specialization}</span>
+                              {record.dentist.profile.specialty && (
+                                <span className="block">{record.dentist.profile.specialty}</span>
                               )}
                             </p>
                           )}

--- a/src/components/ProfileCompletionDialog.tsx
+++ b/src/components/ProfileCompletionDialog.tsx
@@ -1,0 +1,222 @@
+import { useEffect, useState } from "react";
+import { supabase } from "@/integrations/supabase/client";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+
+interface MissingField {
+  key: string;
+  question: string;
+  type: "text" | "date" | "languages";
+  table: "profiles" | "dentists";
+}
+
+const availableLanguages = ["English", "French", "Dutch"];
+
+const ProfileCompletionDialog = () => {
+  const [open, setOpen] = useState(false);
+  const [profileId, setProfileId] = useState<string>("");
+  const [missingFields, setMissingFields] = useState<MissingField[]>([]);
+  const [currentIndex, setCurrentIndex] = useState(0);
+  const [value, setValue] = useState("");
+  const [selectedLanguages, setSelectedLanguages] = useState<string[]>([]);
+  const [completed, setCompleted] = useState(false);
+
+  const checkProfile = async (userId: string) => {
+    const { data, error } = await supabase
+      .from("profiles")
+      .select(
+        `id, role, first_name, last_name, phone, date_of_birth, address, emergency_contact,
+         dentists!dentists_profile_id_fkey(clinic_address, languages, specialty)`
+      )
+      .eq("user_id", userId)
+      .single();
+
+    if (error || !data) return;
+
+    setProfileId(data.id);
+
+    const fields: MissingField[] = [];
+    const base: MissingField[] = [
+      { key: "first_name", question: "What's your first name?", type: "text", table: "profiles" },
+      { key: "last_name", question: "And your last name?", type: "text", table: "profiles" },
+      { key: "phone", question: "What's your phone number?", type: "text", table: "profiles" },
+      { key: "date_of_birth", question: "What is your date of birth?", type: "date", table: "profiles" },
+      { key: "address", question: "Your address?", type: "text", table: "profiles" },
+    ];
+
+    base.forEach((f) => {
+      if (!data[f.key as keyof typeof data]) fields.push(f);
+    });
+
+    if (data.role === "patient") {
+      if (!data.emergency_contact) {
+        fields.push({
+          key: "emergency_contact",
+          question: "Emergency contact?",
+          type: "text",
+          table: "profiles",
+        });
+      }
+    } else if (data.role === "dentist") {
+      const dentist = (data as any).dentists?.[0];
+      if (!dentist?.clinic_address) {
+        fields.push({
+          key: "clinic_address",
+          question: "Clinic address?",
+          type: "text",
+          table: "dentists",
+        });
+      }
+      if (!dentist?.languages || dentist.languages.length === 0) {
+        fields.push({
+          key: "languages",
+          question: "Languages spoken?",
+          type: "languages",
+          table: "dentists",
+        });
+      }
+      if (!dentist?.specialty) {
+        fields.push({
+          key: "specialty",
+          question: "What is your specialty?",
+          type: "text",
+          table: "dentists",
+        });
+      }
+    }
+
+    if (fields.length > 0) {
+      setMissingFields(fields);
+      setOpen(true);
+    }
+  };
+
+  useEffect(() => {
+    const init = async () => {
+      const { data: { session } } = await supabase.auth.getSession();
+      if (session?.user) {
+        checkProfile(session.user.id);
+      }
+    };
+
+    init();
+
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((_event, session) => {
+      if (session?.user) {
+        checkProfile(session.user.id);
+      }
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  const handleNext = async () => {
+    const field = missingFields[currentIndex];
+    if (!field) return;
+
+    let update;
+    if (field.type === "languages") {
+      update = supabase
+        .from("dentists")
+        .update({ languages: selectedLanguages })
+        .eq("profile_id", profileId);
+    } else if (field.table === "profiles") {
+      update = supabase
+        .from("profiles")
+        .update({ [field.key]: value })
+        .eq("id", profileId);
+    } else {
+      update = supabase
+        .from("dentists")
+        .update({ [field.key]: value })
+        .eq("profile_id", profileId);
+    }
+
+    const { error } = await update;
+    if (error) return;
+
+    setValue("");
+    setSelectedLanguages([]);
+    const next = currentIndex + 1;
+    if (next < missingFields.length) {
+      setCurrentIndex(next);
+    } else {
+      setCompleted(true);
+      setTimeout(() => {
+        setOpen(false);
+      }, 1500);
+    }
+  };
+
+  const field = missingFields[currentIndex];
+
+  return (
+    <Dialog open={open}>
+      <DialogContent>
+        {!completed && field && (
+          <>
+            <DialogHeader>
+              <DialogTitle>{field.question}</DialogTitle>
+            </DialogHeader>
+            {field.type === "text" && (
+              <Input value={value} onChange={(e) => setValue(e.target.value)} />
+            )}
+            {field.type === "date" && (
+              <Input type="date" value={value} onChange={(e) => setValue(e.target.value)} />
+            )}
+            {field.type === "languages" && (
+              <div className="space-y-2">
+                {availableLanguages.map((lang) => (
+                  <div key={lang} className="flex items-center space-x-2">
+                    <Checkbox
+                      id={lang}
+                      checked={selectedLanguages.includes(lang)}
+                      onCheckedChange={(checked) => {
+                        if (checked) {
+                          setSelectedLanguages([...selectedLanguages, lang]);
+                        } else {
+                          setSelectedLanguages(selectedLanguages.filter((l) => l !== lang));
+                        }
+                      }}
+                    />
+                    <label htmlFor={lang}>{lang}</label>
+                  </div>
+                ))}
+              </div>
+            )}
+            <div className="mt-4 flex justify-end">
+              <Button
+                onClick={handleNext}
+                disabled={
+                  field.type === "languages"
+                    ? selectedLanguages.length === 0
+                    : value === ""
+                }
+              >
+                Next
+              </Button>
+            </div>
+          </>
+        )}
+        {completed && (
+          <div className="py-8 text-center">
+            <DialogHeader>
+              <DialogTitle>Profile complete! Thank you.</DialogTitle>
+            </DialogHeader>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+};
+
+export default ProfileCompletionDialog;

--- a/src/components/chat/ChatBookingFlow.tsx
+++ b/src/components/chat/ChatBookingFlow.tsx
@@ -55,7 +55,7 @@ export const ChatBookingFlow = ({
         .from("dentists")
         .select(`
           id,
-          specialization,
+          specialty,
           profiles:profile_id (
             first_name,
             last_name

--- a/src/components/chat/InteractiveChatWidgets.tsx
+++ b/src/components/chat/InteractiveChatWidgets.tsx
@@ -193,7 +193,7 @@ const DentistSelectionWidget = ({
                   <h3 className="font-semibold">
                     Dr. {dentist.profiles?.first_name} {dentist.profiles?.last_name}
                   </h3>
-                  <p className="text-sm text-muted-foreground">{dentist.specialization}</p>
+                  <p className="text-sm text-muted-foreground">{dentist.specialty}</p>
                   <Badge variant="secondary" className="text-xs mt-1">Available</Badge>
                 </div>
                 <Button size="sm" onClick={() => onSelect(dentist)}>

--- a/src/components/chat/InteractiveDentalChat.tsx
+++ b/src/components/chat/InteractiveDentalChat.tsx
@@ -486,7 +486,7 @@ Just type what you need or use the quick action buttons! 😊
         .from("dentists")
         .select(`
           id,
-          specialization,
+          specialty,
           profiles:profile_id (
             first_name,
             last_name

--- a/src/components/enhanced/EnhancedPatientDossier.tsx
+++ b/src/components/enhanced/EnhancedPatientDossier.tsx
@@ -187,7 +187,7 @@ export const EnhancedPatientDossier = ({
       .select(`
         *,
         dentist:dentists(
-          profile:profiles(first_name, last_name, specialization)
+          profile:profiles(first_name, last_name, specialty)
         )
       `)
       .eq('patient_id', profileId)

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -581,42 +581,48 @@ export type Database = {
       dentists: {
         Row: {
           average_rating: number | null
+          clinic_address: string | null
           communication_score: number | null
           created_at: string
           expertise_score: number | null
           id: string
           is_active: boolean | null
+          languages: string[] | null
           license_number: string | null
           profile_id: string
-          specialization: string | null
+          specialty: string | null
           total_ratings: number | null
           updated_at: string
           wait_time_score: number | null
         }
         Insert: {
           average_rating?: number | null
+          clinic_address?: string | null
           communication_score?: number | null
           created_at?: string
           expertise_score?: number | null
           id?: string
           is_active?: boolean | null
+          languages?: string[] | null
           license_number?: string | null
           profile_id: string
-          specialization?: string | null
+          specialty?: string | null
           total_ratings?: number | null
           updated_at?: string
           wait_time_score?: number | null
         }
         Update: {
           average_rating?: number | null
+          clinic_address?: string | null
           communication_score?: number | null
           created_at?: string
           expertise_score?: number | null
           id?: string
           is_active?: boolean | null
+          languages?: string[] | null
           license_number?: string | null
           profile_id?: string
-          specialization?: string | null
+          specialty?: string | null
           total_ratings?: number | null
           updated_at?: string
           wait_time_score?: number | null

--- a/src/pages/DentistProfiles.tsx
+++ b/src/pages/DentistProfiles.tsx
@@ -74,7 +74,7 @@ const DentistProfiles = () => {
                   Dr. {dentist.profiles?.first_name} {dentist.profiles?.last_name}
                 </CardTitle>
                 <Badge variant="secondary" className="w-fit mx-auto">
-                  {dentist.specialization}
+                  {dentist.specialty}
                 </Badge>
               </CardHeader>
               <CardContent className="space-y-4">

--- a/supabase/migrations/20250804151000_add_dentist_profile_fields.sql
+++ b/supabase/migrations/20250804151000_add_dentist_profile_fields.sql
@@ -1,0 +1,7 @@
+-- Add clinic_address, languages and rename specialization to specialty in dentists table
+ALTER TABLE public.dentists
+  RENAME COLUMN specialization TO specialty;
+
+ALTER TABLE public.dentists
+  ADD COLUMN clinic_address TEXT,
+  ADD COLUMN languages TEXT[];


### PR DESCRIPTION
## Summary
- prompt users for missing profile data on login and save step-by-step
- rename dentist specialization to specialty and add clinic address & languages fields
- integrate profile completion dialog into app

## Testing
- `npm run lint` *(fails: Unexpected any and other lint errors)*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_688f66e719b4832cb5e79585007cb78d