### PR TITLE
Fix fetchPatients initialization error

### DIFF
--- a/src/components/EnhancedPatientManagement.tsx
+++ b/src/components/EnhancedPatientManagement.tsx
@@ -123,7 +123,7 @@ export function EnhancedPatientManagement({ dentistId }: EnhancedPatientManageme
   useEffect(() => {
     fetchPatients();
     fetchDentistProfile();
-  }, [dentistId, fetchPatients, fetchDentistProfile]);
+  }, [dentistId]);
 
   // Clear error when component unmounts or dentistId changes
   useEffect(() => {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Remove `fetchPatients` and `fetchDentistProfile` from `useEffect` dependencies to fix `ReferenceError: Cannot access 'fetchPatients' before initialization`.

---
<a href="https://cursor.com/background-agent?bcId=bc-5d020be9-8993-4b81-b9e0-e60762758d34">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5d020be9-8993-4b81-b9e0-e60762758d34">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>