### PR TITLE
Fix filterPatients initialization error

### DIFF
--- a/src/components/EnhancedPatientManagement.tsx
+++ b/src/components/EnhancedPatientManagement.tsx
@@ -131,9 +131,7 @@ export function EnhancedPatientManagement({ dentistId }: EnhancedPatientManageme
     setRetryCount(0);
   }, [dentistId]);
 
-  useEffect(() => {
-    filterPatients();
-  }, [filterPatients]);
+
 
   const fetchDentistProfile = useCallback(async () => {
     try {
@@ -284,6 +282,20 @@ export function EnhancedPatientManagement({ dentistId }: EnhancedPatientManageme
     }
   }, [dentistId, toast]);
 
+  // Add useEffect to filter patients when searchTerm or patients change
+  useEffect(() => {
+    if (!searchTerm.trim()) {
+      setFilteredPatients(patients);
+      return;
+    }
+
+    const filtered = patients.filter(patient =>
+      `${patient.first_name || ''} ${patient.last_name || ''}`.toLowerCase().includes(searchTerm.toLowerCase()) ||
+      (patient.email || '').toLowerCase().includes(searchTerm.toLowerCase())
+    );
+    setFilteredPatients(filtered);
+  }, [searchTerm, patients]);
+
   const fetchPatientData = async (patientId: string, retryAttempt = 0) => {
     try {
       setError(null);
@@ -395,18 +407,7 @@ export function EnhancedPatientManagement({ dentistId }: EnhancedPatientManageme
     }
   };
 
-  const filterPatients = useCallback(() => {
-    if (!searchTerm.trim()) {
-      setFilteredPatients(patients);
-      return;
-    }
 
-    const filtered = patients.filter(patient =>
-      `${patient.first_name || ''} ${patient.last_name || ''}`.toLowerCase().includes(searchTerm.toLowerCase()) ||
-      (patient.email || '').toLowerCase().includes(searchTerm.toLowerCase())
-    );
-    setFilteredPatients(filtered);
-  }, [searchTerm, patients]);
 
   const handlePatientSelect = (patient: Patient) => {
     setSelectedPatient(patient);


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Refactor patient filtering logic to resolve 'Cannot access before initialization' error.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The `filterPatients` function was being called in a `useEffect` that listed `filterPatients` as a dependency, but the function itself was defined later, leading to a circular dependency and a `ReferenceError`. The filtering logic is now directly integrated into a `useEffect` that correctly responds to changes in `searchTerm` or `patients`.

---
<a href="https://cursor.com/background-agent?bcId=bc-f02287ec-9b2f-4bd1-b7af-948ff7fd6de9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f02287ec-9b2f-4bd1-b7af-948ff7fd6de9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>