### PR TITLE
Handle missing notification preferences

### DIFF
--- a/src/lib/notificationService.ts
+++ b/src/lib/notificationService.ts
@@ -151,7 +151,7 @@ export class NotificationService {
       .from('notification_preferences')
       .select('*')
       .eq('user_id', userId)
-      .single();
+      .maybeSingle();
 
     if (error) {
       console.error('Error fetching notification preferences:', error);


### PR DESCRIPTION
## Summary
- prevent errors when no notification preferences exist by using `maybeSingle` query

## Testing
- `npm test` *(fails: IntersectionObserver type mismatch)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_b_68952b9644fc832ca543da2e347ae363