### PR TITLE
Fix dentist dashboard appointment error

### DIFF
--- a/src/components/ClinicalToday.tsx
+++ b/src/components/ClinicalToday.tsx
@@ -473,6 +473,9 @@ function SwipeableAppointmentCard({ appointment, onOpenDetails, onComplete, onRe
 	const startX = useRef<number | null>(null);
 	const threshold = 30;
 
+	// Local time formatter to avoid undefined reference
+	const formatTime = (iso: string) => new Date(iso).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+
 	const onTouchStart = (e: React.TouchEvent) => {
 		startX.current = e.touches[0].clientX;
 	};


### PR DESCRIPTION
Add local `formatTime` function to `SwipeableAppointmentCard` to fix ReferenceError on dentist dashboard.

The `SwipeableAppointmentCard` component was attempting to use `formatTime` without it being defined in its scope, leading to a ReferenceError and an error state on the dentist dashboard when appointments were rendered.

---
<a href="https://cursor.com/background-agent?bcId=bc-548f5592-3626-464b-b1e8-c35b57f7fe77">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-548f5592-3626-464b-b1e8-c35b57f7fe77">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

