### PR TITLE
Fix unterminated regexp literal in analytics

### DIFF
--- a/src/components/analytics/DentistAnalytics.tsx
+++ b/src/components/analytics/DentistAnalytics.tsx
@@ -108,8 +108,7 @@ export const DentistAnalytics = ({ dentistId, onOpenPatientsTab, onOpenClinicalT
     const escape = (val: any) => {
       if (val == null) return '';
       const s = String(val).replace(/"/g, '""');
-      return /[",
-]/.test(s) ? `"${s}"` : s;
+      return /[",\r\n]/.test(s) ? `"${s}"` : s;
     };
     const lines = [headers.join(',')].concat(rows.map(r => headers.map(h => escape(r[h])).join(',')));
     return lines.join('\n');


### PR DESCRIPTION
Fix unterminated regex literal in `DentistAnalytics.tsx` to resolve a syntax error and improve CSV escaping.

---
<a href="https://cursor.com/background-agent?bcId=bc-f351cf9b-06cf-4d07-836d-0453c3b2ceb7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f351cf9b-06cf-4d07-836d-0453c3b2ceb7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

