### PR TITLE
Fix messaging unable to create conversation

### DIFF
--- a/src/components/messages/MessagesInbox.tsx
+++ b/src/components/messages/MessagesInbox.tsx
@@ -182,11 +182,12 @@ export function MessagesInbox({ onOpenConversation }: MessagesInboxProps) {
       const { data: { user } } = await supabase.auth.getUser();
       if (!user) return;
 
-      // Create conversation
+      // Create conversation with created_by to satisfy RLS policies
       const { data: conversation, error: convError } = await supabase
         .from('conversations')
         .insert({
-          title: null
+          title: null,
+          created_by: user.id
         })
         .select()
         .single();

--- a/supabase/migrations/20250816093000_fix_conversations_created_by_and_policies.sql
+++ b/supabase/migrations/20250816093000_fix_conversations_created_by_and_policies.sql
@@ -1,0 +1,43 @@
+-- Ensure conversations.created_by exists and policies allow creator to add participants
+
+-- Add created_by column if missing
+ALTER TABLE public.conversations
+ADD COLUMN IF NOT EXISTS created_by uuid REFERENCES auth.users(id) ON DELETE SET NULL;
+
+-- Create trigger to populate created_by with current auth uid if not provided
+CREATE OR REPLACE FUNCTION public.set_conversation_created_by()
+RETURNS trigger AS $$
+BEGIN
+  IF NEW.created_by IS NULL THEN
+    NEW.created_by := auth.uid();
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS conversations_set_created_by ON public.conversations;
+CREATE TRIGGER conversations_set_created_by
+BEFORE INSERT ON public.conversations
+FOR EACH ROW EXECUTE FUNCTION public.set_conversation_created_by();
+
+-- Conversations insert policy to allow any authenticated user to create
+CREATE POLICY IF NOT EXISTS conversations_insert_any ON public.conversations
+FOR INSERT WITH CHECK (auth.uid() IS NOT NULL);
+
+-- Allow creator to add any participants to their conversation
+CREATE POLICY IF NOT EXISTS participants_insert_creator ON public.conversation_participants
+FOR INSERT WITH CHECK (
+  EXISTS (
+    SELECT 1 FROM public.conversations c
+    WHERE c.id = conversation_id AND c.created_by = auth.uid()
+  )
+);
+
+-- Ensure messages insert requires membership and correct sender
+CREATE POLICY IF NOT EXISTS messages_insert_membership ON public.messages
+FOR INSERT WITH CHECK (
+  sender_id = auth.uid() AND EXISTS (
+    SELECT 1 FROM public.conversation_participants cp
+    WHERE cp.conversation_id = messages.conversation_id AND cp.user_id = auth.uid()
+  )
+);


### PR DESCRIPTION
Adds `created_by` to conversations and updates RLS policies to fix "unable to create conversation" error.

The error occurred because the `conversations` table lacked a `created_by` column, and the RLS policy for `conversation_participants` required the creator's ID, causing participant insertion to fail. This PR ensures `created_by` is set and RLS policies are aligned.

---
<a href="https://cursor.com/background-agent?bcId=bc-dcf0549c-f7d5-4cce-81d0-e728c8b73275">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dcf0549c-f7d5-4cce-81d0-e728c8b73275">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

