### PR TITLE
Debug papa.parse not a function error

### DIFF
--- a/supabase/functions/import-appointments/index.ts
+++ b/supabase/functions/import-appointments/index.ts
@@ -1,6 +1,6 @@
 import { serve } from "https://deno.land/std@0.190.0/http/server.ts";
 import { createClient } from "https://esm.sh/@supabase/supabase-js@2.45.0";
-import * as Papa from "https://esm.sh/papaparse@5.4.1";
+import Papa from "https://esm.sh/papaparse@5.4.1";
 import * as XLSX from "https://esm.sh/xlsx@0.18.5";
 import ICAL from "https://esm.sh/ical.js@1.5.0";
 
@@ -37,7 +37,9 @@ function toIsoUtc(dateLike: string | Date): string | null {
 }
 
 function parseCsv(content: string): { rows: any[]; delimiter: string } {
-	const parsed = Papa.parse(content, { header: true, skipEmptyLines: true, dynamicTyping: false });
+	const papaAny: any = (Papa as any);
+	const papa = papaAny?.parse ? papaAny : papaAny?.default ?? papaAny;
+	const parsed = papa.parse(content, { header: true, skipEmptyLines: true, dynamicTyping: false });
 	return { rows: parsed.data as any[], delimiter: (parsed as any).meta?.delimiter || ',' };
 }
 


### PR DESCRIPTION
Fixes "Papa.parse is not a function" error by adjusting `papaparse` import and usage for Deno compatibility.

The error "Papa.parse is not a function" occurred because `esm.sh` sometimes wraps default exports under a `default` property when imported in Deno, leading to `Papa.parse` being undefined. The change ensures `Papa.parse` is correctly accessed regardless of the import's shape.

---
<a href="https://cursor.com/background-agent?bcId=bc-5b9552be-7467-4fad-83f5-cc6e1ae2b01b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5b9552be-7467-4fad-83f5-cc6e1ae2b01b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

