### PR TITLE
Fix reported issue

### DIFF
--- a/src/integrations/supabase/retry.ts
+++ b/src/integrations/supabase/retry.ts
@@ -1,0 +1,14 @@
+export async function withSchemaReloadRetry<T>(op: () => Promise<T>, sb: any): Promise<T> {
+	try {
+		return await op();
+	} catch (e: any) {
+		const message = (e?.message || '').toString().toLowerCase();
+		const looksLikeSchemaCache = message.includes('schema cache') || message.includes('cached schema');
+		if (!looksLikeSchemaCache) throw e;
+		try {
+			await sb.rpc('reload_postgrest_schema');
+		} catch {}
+		await new Promise(r => setTimeout(r, 600));
+		return await op();
+	}
+}

--- a/supabase/migrations/20250817124500_reload_schema_after_invoices.sql
+++ b/supabase/migrations/20250817124500_reload_schema_after_invoices.sql
@@ -1,0 +1,18 @@
+-- Force PostgREST to reload its schema cache so new tables/functions are immediately available
+-- This addresses transient "Could not find the table 'public.invoices' in the schema cache" errors
+
+NOTIFY pgrst, 'reload schema';
+
+-- Safe RPC to reload schema on demand
+CREATE OR REPLACE FUNCTION public.reload_postgrest_schema()
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+BEGIN
+  PERFORM pg_notify('pgrst', 'reload schema');
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.reload_postgrest_schema() FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.reload_postgrest_schema() TO anon, authenticated;


### PR DESCRIPTION
Add schema reload and retry logic to fix transient "table not found" errors for invoices.

The "Could not find the table 'public.invoices' in the schema cache" error occurs due to PostgREST's schema cache not being immediately updated after table creation. This PR introduces a database migration to force a schema reload and an app-side retry mechanism that triggers a schema reload RPC and retries the operation when this specific error is encountered.

---
<a href="https://cursor.com/background-agent?bcId=bc-8564a916-df74-4b3b-a0a0-afb5dba3aebd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8564a916-df74-4b3b-a0a0-afb5dba3aebd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

