### PR TITLE
Remove import csv button from patient tab

### DIFF
--- a/src/components/PatientManagement.tsx
+++ b/src/components/PatientManagement.tsx
@@ -696,11 +696,6 @@ export function PatientManagement({ dentistId }: PatientManagementProps) {
             <span>My Patients</span>
             <Badge variant="outline" className="ml-auto">{patients.length} total</Badge>
           </CardTitle>
-          <div className="flex justify-end">
-            <Button size="sm" variant="outline" onClick={() => navigate('/importer')}>
-              Import (CSV / Excel / iCal)
-            </Button>
-          </div>
           <div className="space-y-4">
             <div className="relative">
               <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 h-5 w-5 text-muted-foreground" />


### PR DESCRIPTION
Remove the 'Import (CSV / Excel / iCal)' button from the patient management dashboard.

---
<a href="https://cursor.com/background-agent?bcId=bc-c4677617-149c-494b-a892-a077413d2d40">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c4677617-149c-494b-a892-a077413d2d40">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

