### PR TITLE
Move settings and notifications to top-right menu

### DIFF
--- a/src/components/PatientDashboard.tsx
+++ b/src/components/PatientDashboard.tsx
@@ -11,7 +11,6 @@ import { PatientPaymentHistory } from "@/components/PatientPaymentHistory";
 import { EmergencyTriageForm } from "@/components/EmergencyTriageForm";
 import { PatientAnalytics } from "@/components/analytics/PatientAnalytics";
 import { DatabaseTest } from "@/components/DatabaseTest";
-import { NotificationButton } from "@/components/NotificationButton";
 import { NotificationTest } from "@/components/NotificationTest";
 import { useLanguage } from "@/hooks/useLanguage";
 import { Button } from "@/components/ui/button";
@@ -577,6 +576,7 @@ export const PatientDashboard = ({ user }: PatientDashboardProps) => {
       activeSection={activeSection}
       onChangeSection={setActiveSection}
       badges={badges}
+      userId={user.id}
     >
       {activeSection === 'home' && (
         <HomeTab

--- a/src/components/patient/HomeTab.tsx
+++ b/src/components/patient/HomeTab.tsx
@@ -4,7 +4,6 @@ import { Card, CardContent, CardHeader, CardTitle, CardDescription } from "@/com
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
-import { NotificationButton } from "@/components/NotificationButton";
 import { Progress } from "@/components/ui/progress";
 import { motion, AnimatePresence } from "framer-motion";
 import {
@@ -15,8 +14,6 @@ import {
   ClipboardList,
   CreditCard,
   MessageSquare,
-  User as UserIcon,
-  Bell,
   Heart,
   Activity,
   Clock,
@@ -36,7 +33,6 @@ import {
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { RecallBanner } from "@/components/patient/RecallBanner";
-import { useMemo } from "react";
 import { supabase } from "@/integrations/supabase/client";
 import { getPatientActiveRecall, RecallRecord } from "@/lib/recalls";
 import { useLanguage } from "@/hooks/useLanguage";
@@ -121,7 +117,6 @@ export const HomeTab: React.FC<HomeTabProps> = ({
             <p className="text-muted-foreground">{t.hereIsYourHealthOverview}</p>
           </div>
         </div>
-        <NotificationButton userId={userId} />
       </motion.div>
 
       {activeRecall && (

--- a/src/components/patient/PatientAppShell.tsx
+++ b/src/components/patient/PatientAppShell.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState, useEffect } from "react";
+import React from "react";
 import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
@@ -11,10 +11,7 @@ import {
   CreditCard,
   Settings as SettingsIcon,
   Bot,
-  Menu,
-  X,
   LogOut,
-  User,
   Info
 } from "lucide-react";
 import {
@@ -25,6 +22,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
+import { NotificationButton } from "@/components/NotificationButton";
 import { supabase } from "@/integrations/supabase/client";
 import { useToast } from "@/hooks/use-toast";
 
@@ -35,6 +33,7 @@ interface PatientAppShellProps {
   onChangeSection: (section: PatientSection) => void;
   children: React.ReactNode;
   badges?: Partial<Record<PatientSection, boolean>>;
+  userId: string;
 }
 
 // Simplified navigation items - only bottom bar, no duplication
@@ -44,7 +43,6 @@ const NAV_ITEMS: Array<{ id: PatientSection; label: string; shortLabel?: string;
   { id: 'care', label: 'Treatment Records', shortLabel: 'Records', icon: FolderOpen, color: 'text-purple-600 bg-purple-100 dark:bg-purple-900/30' },
   { id: 'appointments', label: 'Appointments', shortLabel: 'Appts', icon: Calendar, color: 'text-orange-600 bg-orange-100 dark:bg-orange-900/30' },
   { id: 'payments', label: 'Payments', icon: CreditCard, color: 'text-green-600 bg-green-100 dark:bg-green-900/30' },
-  { id: 'settings', label: 'Settings', icon: SettingsIcon, color: 'text-gray-600 bg-gray-100 dark:bg-gray-900/30' },
 ];
 
 export const PatientAppShell: React.FC<PatientAppShellProps> = ({
@@ -52,8 +50,8 @@ export const PatientAppShell: React.FC<PatientAppShellProps> = ({
   onChangeSection,
   children,
   badges = {},
+  userId,
 }) => {
-  const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
   const { toast } = useToast();
   const navigate = useNavigate();
 
@@ -83,32 +81,34 @@ export const PatientAppShell: React.FC<PatientAppShellProps> = ({
             </div>
             <span className="font-semibold text-lg">Patient Portal</span>
           </div>
-          
-          {/* Simple dropdown menu for extra options */}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon" className="hover:bg-primary/10">
-                <Menu className="h-5 w-5" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-48">
-              <DropdownMenuLabel>Menu</DropdownMenuLabel>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={() => onChangeSection('settings')}>
-                <User className="mr-2 h-4 w-4" />
-                Profile
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => navigate('/about')}>
-                <Info className="mr-2 h-4 w-4" />
-                About Dentibot
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
-              <DropdownMenuItem onClick={handleSignOut} className="text-red-600">
-                <LogOut className="mr-2 h-4 w-4" />
-                Sign Out
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
+
+          <div className="flex items-center space-x-2">
+            <NotificationButton userId={userId} />
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button variant="ghost" size="icon" className="hover:bg-primary/10">
+                  <SettingsIcon className="h-5 w-5" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-48">
+                <DropdownMenuLabel>Menu</DropdownMenuLabel>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={() => onChangeSection('settings')}>
+                  <SettingsIcon className="mr-2 h-4 w-4" />
+                  Settings
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => navigate('/about')}>
+                  <Info className="mr-2 h-4 w-4" />
+                  About Dentinot
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem onClick={handleSignOut} className="text-red-600">
+                  <LogOut className="mr-2 h-4 w-4" />
+                  Sign Out
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
         </div>
       </div>
 
@@ -121,23 +121,23 @@ export const PatientAppShell: React.FC<PatientAppShellProps> = ({
             </div>
             <span className="font-semibold text-xl">Patient Portal</span>
           </div>
-          
+
           <div className="flex items-center space-x-2">
+            <NotificationButton userId={userId} />
             <DropdownMenu>
               <DropdownMenuTrigger asChild>
-                <Button variant="ghost" size="sm" className="hover:bg-primary/10">
-                  <User className="h-4 w-4 mr-2" />
-                  Account
+                <Button variant="ghost" size="icon" className="hover:bg-primary/10">
+                  <SettingsIcon className="h-5 w-5" />
                 </Button>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="w-48">
                 <DropdownMenuItem onClick={() => onChangeSection('settings')}>
-                  <User className="mr-2 h-4 w-4" />
-                  Profile Settings
+                  <SettingsIcon className="mr-2 h-4 w-4" />
+                  Settings
                 </DropdownMenuItem>
                 <DropdownMenuItem onClick={() => navigate('/about')}>
                   <Info className="mr-2 h-4 w-4" />
-                  About Dentibot
+                  About Dentinot
                 </DropdownMenuItem>
                 <DropdownMenuSeparator />
                 <DropdownMenuItem onClick={handleSignOut} className="text-red-600">

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -4,9 +4,9 @@ const About = () => {
   return (
     <div className="min-h-screen bg-background">
       <div className="container mx-auto px-4 py-12 max-w-3xl">
-        <h1 className="text-3xl font-bold tracking-tight mb-6">About Dentibot</h1>
+        <h1 className="text-3xl font-bold tracking-tight mb-6">About Dentinot</h1>
         <p className="text-muted-foreground leading-relaxed mb-6">
-          Dentibot is an AI-powered assistant created to streamline dental clinic workflows. From patient intake and appointment scheduling to billing, treatment history, and reminders, Dentibot helps reduce administrative work by up to 30%, giving dentists more time to focus on patient care.
+          Dentinot is an AI-powered assistant created to streamline dental clinic workflows. From patient intake and appointment scheduling to billing, treatment history, and reminders, Dentinot helps reduce administrative work by up to 30%, giving dentists more time to focus on patient care.
         </p>
 
         <h2 className="text-2xl font-semibold tracking-tight mb-4">Our Mission</h2>
@@ -26,7 +26,7 @@ const About = () => {
         </ul>
 
         <p className="text-muted-foreground leading-relaxed">
-          Dentibot is developed by Caberu SRL, founded by Romeo Jackson and Thomas Iordache, with a vision to modernize dental care through secure, intelligent automation.
+          Dentinot is developed by Caberu SRL, founded by Romeo Jackson and Thomas Iordache, with a vision to modernize dental care through secure, intelligent automation.
         </p>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- Move settings navigation into a top-right gear menu alongside notifications
- Add About Dentinot link and rename About page content
- Remove notification button from home tab

## Testing
- `npm test` *(fails: useNavigate requires Router, crypto.randomUUID missing, etc.)*

------
https://chatgpt.com/codex/tasks/task_b_68a5efd791b0832ca5fa9175cc0c0fc5