### PR TITLE
Remove recalls button from inventory

### DIFF
--- a/src/components/MobileDentistTabs.tsx
+++ b/src/components/MobileDentistTabs.tsx
@@ -15,7 +15,7 @@ import {
   Package
 } from "lucide-react";
 
-type TabType = 'clinical' | 'patients' | 'payments' | 'analytics' | 'availability' | 'manage' | 'debug' | 'inventory' | 'recalls' | 'import';
+type TabType = 'clinical' | 'patients' | 'payments' | 'analytics' | 'availability' | 'manage' | 'debug' | 'inventory' | 'import';
 
 interface MobileDentistTabsProps {
   activeTab: TabType;
@@ -68,7 +68,6 @@ export function MobileDentistTabs({ activeTab, setActiveTab, dentistId, children
       icon: Package,
       tabs: [
         { id: 'inventory' as TabType, label: 'Inventory', icon: Package, badge: inventoryBadgeCount > 0 ? String(inventoryBadgeCount) : undefined },
-        { id: 'recalls' as TabType, label: 'Recalls', icon: Calendar },
       ]
     },
     {


### PR DESCRIPTION
Remove the recalls button from the inventory section.

---
<a href="https://cursor.com/background-agent?bcId=bc-8fd8bdef-1e52-43e3-8740-420bcd3e3ec0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8fd8bdef-1e52-43e3-8740-420bcd3e3ec0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

