### PR TITLE
Update patient dashboard home tab layout

### DIFF
--- a/src/components/patient/HomeTab.tsx
+++ b/src/components/patient/HomeTab.tsx
@@ -133,7 +133,7 @@ export const HomeTab: React.FC<HomeTabProps> = ({
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.1 }}
-          className="md:col-span-2 lg:col-span-2"
+          className="md:col-span-2 lg:col-span-4"
         >
           <Card className="h-full border-2 hover:border-primary/30 transition-all hover:shadow-lg">
             <CardHeader className="pb-3">
@@ -304,110 +304,6 @@ export const HomeTab: React.FC<HomeTabProps> = ({
                   <MessageSquare className="h-4 w-4 mr-2" />
                   {t.startChat}
                 </Button>
-              </div>
-            </CardContent>
-          </Card>
-        </motion.div>
-      </div>
-
-      {/* Secondary Section - Daily Tips & Health Stats */}
-      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 mt-8">
-        
-        {/* Daily Tips & Reminders */}
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.5 }}
-          className="lg:col-span-1"
-        >
-          <Card className="h-full">
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2 text-lg">
-                <Info className="h-5 w-5 text-blue-600" />
-                {t.dailyTipsReminders}
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-3">
-              <div className="p-3 bg-blue-50 dark:bg-blue-900/20 rounded-lg">
-                <p className="text-sm font-medium flex items-center gap-2">
-                  <Clock className="h-4 w-4 text-blue-600" />
-                  {t.morningReminder}
-                </p>
-                <p className="text-xs text-muted-foreground mt-1">
-                  {t.dontForgetToBrush}
-                </p>
-              </div>
-              <div className="p-3 bg-green-50 dark:bg-green-900/20 rounded-lg">
-                <p className="text-sm font-medium flex items-center gap-2">
-                  <Heart className="h-4 w-4 text-green-600" />
-                  {t.healthTip}
-                </p>
-                <p className="text-xs text-muted-foreground mt-1">
-                  {t.flossingDaily}
-                </p>
-              </div>
-              <div className="p-3 bg-amber-50 dark:bg-amber-900/20 rounded-lg">
-                <p className="text-sm font-medium flex items-center gap-2">
-                  <AlertCircle className="h-4 w-4 text-amber-600" />
-                  {t.upcoming}
-                </p>
-                <p className="text-xs text-muted-foreground mt-1">
-                  {t.dentalCleaningRecommended}
-                </p>
-              </div>
-            </CardContent>
-          </Card>
-        </motion.div>
-
-        {/* Health Stats Grid */}
-        <motion.div
-          initial={{ opacity: 0, y: 20 }}
-          animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 0.6 }}
-          className="lg:col-span-2"
-        >
-          <Card className="h-full">
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2 text-lg">
-                <Activity className="h-5 w-5 text-purple-600" />
-                {t.healthStats}
-              </CardTitle>
-            </CardHeader>
-            <CardContent>
-              <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                {/* Health Rating */}
-                <div className="text-center p-4 bg-gradient-to-br from-green-50 to-green-100/50 dark:from-green-900/20 dark:to-green-900/10 rounded-lg">
-                  <div className="relative inline-flex items-center justify-center">
-                    <Progress value={healthRating} className="h-16 w-16 rounded-full" />
-                    <span className="absolute text-lg font-bold">{healthRating}%</span>
-                  </div>
-                  <p className="text-xs font-medium mt-2">{t.healthRating}</p>
-                  <p className="text-xs text-muted-foreground">{t.excellent}</p>
-                </div>
-
-                {/* Visits This Year */}
-                <div className="text-center p-4 bg-gradient-to-br from-blue-50 to-blue-100/50 dark:from-blue-900/20 dark:to-blue-900/10 rounded-lg">
-                  <Calendar className="h-8 w-8 text-blue-600 mx-auto mb-2" />
-                  <p className="text-2xl font-bold">{visitsThisYear}</p>
-                  <p className="text-xs font-medium">{t.visitsThisYear}</p>
-                  <p className="text-xs text-muted-foreground">{t.onTrack}</p>
-                </div>
-
-                {/* Coverage */}
-                <div className="text-center p-4 bg-gradient-to-br from-purple-50 to-purple-100/50 dark:from-purple-900/20 dark:to-purple-900/10 rounded-lg">
-                  <Shield className="h-8 w-8 text-purple-600 mx-auto mb-2" />
-                  <p className="text-2xl font-bold">{coverageUsed}%</p>
-                  <p className="text-xs font-medium">{t.coverageUsed}</p>
-                  <p className="text-xs text-muted-foreground">€350 {t.remaining}</p>
-                </div>
-
-                {/* Health Improved */}
-                <div className="text-center p-4 bg-gradient-to-br from-emerald-50 to-emerald-100/50 dark:from-emerald-900/20 dark:to-emerald-900/10 rounded-lg">
-                  <TrendingUp className="h-8 w-8 text-emerald-600 mx-auto mb-2" />
-                  <p className="text-2xl font-bold">+{healthImprovement}%</p>
-                  <p className="text-xs font-medium">{t.healthImproved}</p>
-                  <p className="text-xs text-muted-foreground">{t.lastSixMonths}</p>
-                </div>
               </div>
             </CardContent>
           </Card>


### PR DESCRIPTION
Remove daily tips, reminders, and health stats sections, and make the next appointment card full width on the patient dashboard home tab to streamline the layout.

---
<a href="https://cursor.com/background-agent?bcId=bc-a35b8f33-f4f3-41b9-8119-60a9f3110fb7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a35b8f33-f4f3-41b9-8119-60a9f3110fb7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

