### PR TITLE
Add sidebar collapse button

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -100,7 +100,7 @@ function TopBar() {
   return (
     <div className="sticky top-0 z-40 bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b">
       <div className="flex items-center gap-2 px-3 md:px-4 py-2">
-        <SidebarTrigger className="md:hidden" />
+        <SidebarTrigger />
         <div className="flex items-center gap-2 text-muted-foreground">
           <Home className="h-4 w-4" />
           <Separator orientation="vertical" className="h-4" />


### PR DESCRIPTION
Add sidebar collapse buttons to both the dentist and patient applications to improve user control over the layout.

The existing `AppShell` sidebar trigger was hidden on desktop, and the `PatientAppShell` lacked any collapse functionality. This PR addresses both by making the dentist app's trigger visible and implementing a new collapse toggle for the patient app, including state persistence and responsive layout adjustments.

---
<a href="https://cursor.com/background-agent?bcId=bc-a3cadfa6-29e7-4e44-976c-9b7a27702e6a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a3cadfa6-29e7-4e44-976c-9b7a27702e6a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

