### PR TITLE
Investigate missing desktop collapse and sign out buttons

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -54,6 +54,7 @@ import {
   ChevronDown,
   Home,
   PanelLeft,
+  LogOut,
 } from "lucide-react";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
@@ -102,7 +103,7 @@ function TopBar() {
   return (
     <div className="sticky top-0 z-40 bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b">
       <div className="flex items-center gap-2 px-3 md:px-4 py-2">
-        <SidebarTrigger className="md:hidden" />
+        <SidebarTrigger />
         <Button
           variant="outline"
           size="sm"
@@ -163,6 +164,17 @@ function TopBar() {
               <DropdownMenuItem onClick={() => supabase.auth.signOut()}>Sign out</DropdownMenuItem>
             </DropdownMenuContent>
           </DropdownMenu>
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-2"
+            onClick={() => supabase.auth.signOut()}
+            aria-label="Sign out"
+            title="Sign out"
+          >
+            <LogOut className="h-4 w-4" />
+            <span className="hidden sm:inline">Sign out</span>
+          </Button>
         </div>
 
         <GlobalSearch open={openSearch} onOpenChange={setOpenSearch} />


### PR DESCRIPTION
Show the hamburger collapse button on desktop and add a dedicated sign-out button to the top bar.

---
<a href="https://cursor.com/background-agent?bcId=bc-a0284c95-b73f-4dd0-8569-c63f670e5e65">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a0284c95-b73f-4dd0-8569-c63f670e5e65">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

