### PR TITLE
Investigate missing desktop collapse and sign out buttons

### DIFF
--- a/src/components/layout/AppShell.tsx
+++ b/src/components/layout/AppShell.tsx
@@ -54,6 +54,7 @@ import {
   ChevronDown,
   Home,
   PanelLeft,
+  LogOut,
 } from "lucide-react";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuLabel, DropdownMenuSeparator, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { cn } from "@/lib/utils";
@@ -102,7 +103,7 @@ function TopBar() {
   return (
     <div className="sticky top-0 z-40 bg-background/80 backdrop-blur supports-[backdrop-filter]:bg-background/60 border-b">
       <div className="flex items-center gap-2 px-3 md:px-4 py-2">
-        <SidebarTrigger className="md:hidden" />
+        <SidebarTrigger />
         <Button
           variant="outline"
           size="sm"
@@ -447,6 +448,9 @@ export function AppShell() {
               className="flex-1 justify-start"
             >
               <Languages className="h-4 w-4 mr-2" />EN/FR/NL
+            </Button>
+            <Button variant="ghost" size="icon" onClick={() => supabase.auth.signOut()} aria-label="Sign out" title="Sign out">
+              <LogOut className="h-4 w-4" />
             </Button>
             <SidebarTrigger
               className="h-8 w-8"

--- a/src/components/patient/PatientPortalNav.tsx
+++ b/src/components/patient/PatientPortalNav.tsx
@@ -5,7 +5,8 @@ import { Drawer, DrawerContent } from "@/components/ui/drawer";
 import { Button } from "@/components/ui/button";
 import { useIsMobile } from "@/hooks/use-mobile";
 import { useLanguage } from "@/hooks/useLanguage";
-import { Home, Calendar, Pill, FileText, CreditCard, Folder, User, IdCard, Shield, HelpCircle, ChevronDown, MoreHorizontal, PanelLeft } from "lucide-react";
+import { Home, Calendar, Pill, FileText, CreditCard, Folder, User, IdCard, Shield, HelpCircle, ChevronDown, MoreHorizontal, PanelLeft, LogOut } from "lucide-react";
+import { supabase } from "@/integrations/supabase/client";
 import { usePatientBadgeCounts } from "@/hooks/usePatientBadges";
 import { cn } from "@/lib/utils";
 import { emitAnalyticsEvent } from "@/lib/analyticsEvents";
@@ -51,6 +52,13 @@ export function PatientPortalNav({ children }: { children: React.ReactNode }) {
   const [openGroupId, setOpenGroupId] = useState<string | null>(() => localStorage.getItem(STORAGE_KEYS.lastGroup));
   const [moreOpen, setMoreOpen] = useState(false);
   const [defaultOpen, setDefaultOpen] = useState(true);
+
+  const handleSignOut = async () => {
+    try {
+      await supabase.auth.signOut();
+      navigate("/");
+    } catch {}
+  };
 
   useEffect(() => {
     const cookieOpen = readSidebarCookie();
@@ -224,6 +232,9 @@ export function PatientPortalNav({ children }: { children: React.ReactNode }) {
       <SidebarFooter>
         <div className="flex items-center gap-2">
           <Button variant="outline" size="sm" className="flex-1 justify-start">EN/FR/NL</Button>
+          <Button variant="ghost" size="icon" onClick={handleSignOut} aria-label={t.signOut} title={t.signOut}>
+            <LogOut className="h-4 w-4" />
+          </Button>
           <SidebarTrigger className="h-8 w-8" aria-label="Collapse or expand sidebar" title="Collapse/Expand" />
         </div>
       </SidebarFooter>
@@ -289,7 +300,7 @@ export function PatientPortalNav({ children }: { children: React.ReactNode }) {
         <div className="flex-1">
           <div className="sticky top-0 z-40 bg-background/80 backdrop-blur border-b px-3 py-2 flex items-center justify-between">
             <div className="flex items-center gap-2">
-              <SidebarTrigger className="md:hidden" />
+              <SidebarTrigger />
               <Button
                 variant="outline"
                 size="sm"


### PR DESCRIPTION
Expose sidebar collapse trigger on desktop and add visible sign-out buttons to sidebars in both dentist and patient portals.

The collapse trigger was hidden on desktop by a `md:hidden` class, and sign-out was either only in a dropdown (dentist) or completely absent (patient sidebar). This PR makes these essential UI elements readily accessible.

---
<a href="https://cursor.com/background-agent?bcId=bc-ea9c9bf4-1168-46d3-93c7-8e0976e038f6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ea9c9bf4-1168-46d3-93c7-8e0976e038f6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

